### PR TITLE
Add migration importers, Helm chart, package registries, and integration guides

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,26 @@ docker_manifests:
       - "ghcr.io/atoolz/turnis:latest-amd64"
       - "ghcr.io/atoolz/turnis:latest-arm64"
 
+brews:
+  - repository:
+      owner: atoolz
+      name: homebrew-tap
+    homepage: https://github.com/atoolz/turnis
+    description: Open-source Slack-native on-call management
+    install: bin.install "turnis"
+
+nfpms:
+  - id: turnis
+    package_name: turnis
+    vendor: AToolZ
+    homepage: https://github.com/atoolz/turnis
+    description: Open-source Slack-native on-call management
+    license: AGPL-3.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+
 changelog:
   sort: asc
   filters:

--- a/charts/turnis/.helmignore
+++ b/charts/turnis/.helmignore
@@ -1,0 +1,17 @@
+.DS_Store
+.git
+.gitignore
+.bzr
+.bzrignore
+.hg
+.hgignore
+.svn
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea
+*.tmproj
+.vscode

--- a/charts/turnis/Chart.yaml
+++ b/charts/turnis/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: turnis
+description: Open-source Slack-native on-call management
+type: application
+version: 0.5.0
+appVersion: "0.5.0"
+home: https://github.com/atoolz/turnis
+sources:
+  - https://github.com/atoolz/turnis
+maintainers:
+  - name: atoolz
+    url: https://github.com/atoolz
+keywords:
+  - on-call
+  - incident-management
+  - slack
+  - pagerduty-alternative

--- a/charts/turnis/templates/NOTES.txt
+++ b/charts/turnis/templates/NOTES.txt
@@ -1,0 +1,24 @@
+Turnis has been deployed.
+
+1. Get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "turnis.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "turnis.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "turnis.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }}"
+{{- end }}
+
+2. Configure Slack credentials:
+   Set slack.botToken and slack.signingSecret in your values file or via --set flags.
+
+3. (Optional) Configure Twilio for SMS/Voice:
+   Set twilio.accountSid, twilio.authToken, and twilio.fromNumber.

--- a/charts/turnis/templates/_helpers.tpl
+++ b/charts/turnis/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "turnis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "turnis.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "turnis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "turnis.labels" -}}
+helm.sh/chart: {{ include "turnis.chart" . }}
+{{ include "turnis.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "turnis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "turnis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/turnis/templates/configmap.yaml
+++ b/charts/turnis/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "turnis.fullname" . }}
+  labels:
+    {{- include "turnis.labels" . | nindent 4 }}
+data:
+  turnis.yaml: |
+    server:
+      port: {{ .Values.service.port }}
+    database:
+      driver: {{ .Values.database.driver }}
+      dsn: {{ .Values.database.dsn }}
+    ntfy:
+      server: {{ .Values.ntfy.server }}
+    {{- if .Values.email.smtpHost }}
+    email:
+      smtp_host: {{ .Values.email.smtpHost }}
+      smtp_port: {{ .Values.email.smtpPort }}
+      from: {{ .Values.email.from }}
+    {{- end }}
+    log:
+      level: {{ .Values.log.level }}

--- a/charts/turnis/templates/deployment.yaml
+++ b/charts/turnis/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "turnis.fullname" . }}
+  labels:
+    {{- include "turnis.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "turnis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "turnis.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - serve
+            - --config
+            - /etc/turnis/turnis.yaml
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "turnis.fullname" . }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/turnis
+              readOnly: true
+            {{- if and .Values.persistence.enabled (eq .Values.database.driver "sqlite") }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "turnis.fullname" . }}
+        {{- if and .Values.persistence.enabled (eq .Values.database.driver "sqlite") }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "turnis.fullname" . }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/turnis/templates/ingress.yaml
+++ b/charts/turnis/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "turnis.fullname" . }}
+  labels:
+    {{- include "turnis.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "turnis.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/turnis/templates/pvc.yaml
+++ b/charts/turnis/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (eq .Values.database.driver "sqlite") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "turnis.fullname" . }}
+  labels:
+    {{- include "turnis.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/turnis/templates/secret.yaml
+++ b/charts/turnis/templates/secret.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "turnis.fullname" . }}
+  labels:
+    {{- include "turnis.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.slack.botToken }}
+  TURNIS_SLACK_BOT_TOKEN: {{ .Values.slack.botToken | quote }}
+  {{- end }}
+  {{- if .Values.slack.appToken }}
+  TURNIS_SLACK_APP_TOKEN: {{ .Values.slack.appToken | quote }}
+  {{- end }}
+  {{- if .Values.slack.signingSecret }}
+  TURNIS_SLACK_SIGNING_SECRET: {{ .Values.slack.signingSecret | quote }}
+  {{- end }}
+  {{- if .Values.email.username }}
+  TURNIS_EMAIL_USERNAME: {{ .Values.email.username | quote }}
+  {{- end }}
+  {{- if .Values.email.password }}
+  TURNIS_EMAIL_PASSWORD: {{ .Values.email.password | quote }}
+  {{- end }}
+  {{- if .Values.twilio.accountSid }}
+  TURNIS_TWILIO_ACCOUNT_SID: {{ .Values.twilio.accountSid | quote }}
+  {{- end }}
+  {{- if .Values.twilio.authToken }}
+  TURNIS_TWILIO_AUTH_TOKEN: {{ .Values.twilio.authToken | quote }}
+  {{- end }}
+  {{- if .Values.twilio.fromNumber }}
+  TURNIS_TWILIO_FROM_NUMBER: {{ .Values.twilio.fromNumber | quote }}
+  {{- end }}

--- a/charts/turnis/templates/service.yaml
+++ b/charts/turnis/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "turnis.fullname" . }}
+  labels:
+    {{- include "turnis.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "turnis.selectorLabels" . | nindent 4 }}

--- a/charts/turnis/values.yaml
+++ b/charts/turnis/values.yaml
@@ -1,0 +1,73 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/atoolz/turnis
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+
+database:
+  driver: sqlite
+  dsn: /data/turnis.db
+
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: turnis.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+slack:
+  botToken: ""
+  appToken: ""
+  signingSecret: ""
+
+twilio:
+  accountSid: ""
+  authToken: ""
+  fromNumber: ""
+
+ntfy:
+  server: https://ntfy.sh
+
+email:
+  smtpHost: ""
+  smtpPort: 587
+  from: ""
+  username: ""
+  password: ""
+
+log:
+  level: info
+
+resources:
+  requests:
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}

--- a/cmd/turnis/main.go
+++ b/cmd/turnis/main.go
@@ -18,6 +18,7 @@ func main() {
 
 	root.AddCommand(serveCmd())
 	root.AddCommand(versionCmd())
+	root.AddCommand(migrateCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/turnis/migrate.go
+++ b/cmd/turnis/migrate.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func migrateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate from another on-call tool into Turnis",
+	}
+
+	cmd.AddCommand(migrateGrafanaOnCallCmd())
+	cmd.AddCommand(migrateOpsgenieCmd())
+
+	return cmd
+}

--- a/cmd/turnis/migrate_grafana.go
+++ b/cmd/turnis/migrate_grafana.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/atoolz/turnis/internal/config"
+	"github.com/atoolz/turnis/internal/escalation"
+	"github.com/atoolz/turnis/internal/schedule"
+	"github.com/atoolz/turnis/internal/store"
+)
+
+// Grafana OnCall export JSON structures.
+
+type grafanaExport struct {
+	Teams            []grafanaTeam            `json:"teams"`
+	Users            []grafanaUser            `json:"users"`
+	Schedules        []grafanaSchedule        `json:"schedules"`
+	EscalationChains []grafanaEscalationChain `json:"escalation_chains"`
+	Integrations     []grafanaIntegration     `json:"integrations"`
+}
+
+type grafanaTeam struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	SlackChannel string `json:"slack_channel"`
+}
+
+type grafanaUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Phone    string `json:"phone"`
+	SlackID  string `json:"slack_id"`
+}
+
+type grafanaSchedule struct {
+	ID       string         `json:"id"`
+	Name     string         `json:"name"`
+	TeamID   string         `json:"team_id"`
+	Timezone string         `json:"timezone"`
+	Type     string         `json:"type"`
+	Shifts   []grafanaShift `json:"shifts"`
+}
+
+type grafanaShift struct {
+	UserIDs       []string `json:"user_ids"`
+	RotationStart string   `json:"rotation_start"`
+	Frequency     string   `json:"frequency"`
+	Interval      int      `json:"interval"`
+}
+
+type grafanaEscalationChain struct {
+	ID     string                  `json:"id"`
+	Name   string                  `json:"name"`
+	TeamID string                  `json:"team_id"`
+	Steps  []grafanaEscalationStep `json:"steps"`
+}
+
+type grafanaEscalationStep struct {
+	Type          string `json:"type"`
+	TargetID      string `json:"target_id"`
+	Duration      int    `json:"duration"`
+	NotifyChannel string `json:"notify_channel"`
+}
+
+type grafanaIntegration struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	TeamID            string `json:"team_id"`
+	Type              string `json:"type"`
+	EscalationChainID string `json:"escalation_chain_id"`
+}
+
+type migrationReport struct {
+	teamsCreated        int
+	usersCreated        int
+	schedulesCreated    int
+	schedulesSkipped    int
+	policiesCreated     int
+	integrationsCreated int
+	warnings            []string
+}
+
+func (r *migrationReport) print() {
+	fmt.Println("\n=== Migration Report ===")
+	fmt.Printf("Teams created:        %d\n", r.teamsCreated)
+	fmt.Printf("Users created:        %d\n", r.usersCreated)
+	fmt.Printf("Schedules created:    %d\n", r.schedulesCreated)
+	fmt.Printf("Schedules skipped:    %d\n", r.schedulesSkipped)
+	fmt.Printf("Policies created:     %d\n", r.policiesCreated)
+	fmt.Printf("Integrations created: %d\n", r.integrationsCreated)
+	if len(r.warnings) > 0 {
+		fmt.Println("\nWarnings:")
+		for _, w := range r.warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+	fmt.Println()
+}
+
+func migrateGrafanaOnCallCmd() *cobra.Command {
+	var inputFile string
+	var dbDSN string
+
+	cmd := &cobra.Command{
+		Use:   "grafana-oncall",
+		Short: "Import data from a Grafana OnCall JSON export",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if inputFile == "" {
+				return fmt.Errorf("--input is required")
+			}
+			return runGrafanaMigration(inputFile, dbDSN)
+		},
+	}
+
+	cmd.Flags().StringVar(&inputFile, "input", "", "path to Grafana OnCall export JSON file")
+	cmd.Flags().StringVar(&dbDSN, "db", "turnis.db", "SQLite database path")
+
+	return cmd
+}
+
+func runGrafanaMigration(inputFile, dbDSN string) error {
+	data, err := os.ReadFile(inputFile)
+	if err != nil {
+		return fmt.Errorf("reading input file: %w", err)
+	}
+
+	var export grafanaExport
+	if err := json.Unmarshal(data, &export); err != nil {
+		return fmt.Errorf("parsing JSON: %w", err)
+	}
+
+	db, err := store.New(config.DatabaseConfig{Driver: "sqlite", DSN: dbDSN})
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Migrate(); err != nil {
+		return fmt.Errorf("running migrations: %w", err)
+	}
+
+	ctx := context.Background()
+	report := &migrationReport{}
+
+	// ID mappings: old Grafana ID -> new Turnis ID
+	teamMap := make(map[string]string)
+	userMap := make(map[string]string)
+	scheduleMap := make(map[string]string)
+	policyMap := make(map[string]string)
+
+	// 1. Import teams
+	fmt.Println("Importing teams...")
+	for _, gt := range export.Teams {
+		team, err := db.CreateTeam(ctx, gt.Name, gt.SlackChannel)
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create team %q: %v", gt.Name, err))
+			continue
+		}
+		teamMap[gt.ID] = team.ID
+		report.teamsCreated++
+		fmt.Printf("  Team %q -> %s\n", gt.Name, team.ID)
+	}
+
+	// 2. Import users
+	fmt.Println("Importing users...")
+	for _, gu := range export.Users {
+		name := gu.Username
+		if name == "" {
+			name = gu.Email
+		}
+		if gu.Email == "" {
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping user %q: no email address", name))
+			continue
+		}
+		// Users in Grafana OnCall are not team-scoped, so leave team_id empty.
+		user, err := db.CreateUser(ctx, name, gu.Email, gu.Phone, gu.SlackID, "", "")
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create user %q: %v", name, err))
+			continue
+		}
+		userMap[gu.ID] = user.ID
+		report.usersCreated++
+		fmt.Printf("  User %q -> %s\n", name, user.ID)
+	}
+
+	// 3. Import schedules
+	fmt.Println("Importing schedules...")
+	for _, gs := range export.Schedules {
+		if gs.Type == "ical" {
+			report.schedulesSkipped++
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping iCal schedule %q (unsupported)", gs.Name))
+			continue
+		}
+
+		newTeamID := teamMap[gs.TeamID]
+		if newTeamID == "" {
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping schedule %q: team %s not found in mapping", gs.Name, gs.TeamID))
+			report.schedulesSkipped++
+			continue
+		}
+
+		rotationType := mapGrafanaFrequency(gs.Shifts)
+		rotationLength := 1
+		if len(gs.Shifts) > 0 && gs.Shifts[0].Interval > 0 {
+			rotationLength = gs.Shifts[0].Interval
+		}
+
+		sched := &schedule.Schedule{
+			Name:           gs.Name,
+			TeamID:         newTeamID,
+			Timezone:       gs.Timezone,
+			RotationType:   rotationType,
+			RotationLength: rotationLength,
+		}
+
+		// Build a single layer with all participants from all shifts
+		var participants []schedule.Participant
+		position := 0
+		for _, shift := range gs.Shifts {
+			for _, uid := range shift.UserIDs {
+				newUID := userMap[uid]
+				if newUID == "" {
+					report.warnings = append(report.warnings, fmt.Sprintf("schedule %q: user %s not found in mapping, skipping participant", gs.Name, uid))
+					continue
+				}
+				participants = append(participants, schedule.Participant{
+					UserID:   newUID,
+					Position: position,
+				})
+				position++
+			}
+		}
+
+		if len(participants) > 0 {
+			sched.Layers = []schedule.Layer{
+				{Priority: 0, Participants: participants},
+			}
+		}
+
+		created, err := db.CreateSchedule(ctx, sched)
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create schedule %q: %v", gs.Name, err))
+			continue
+		}
+		scheduleMap[gs.ID] = created.ID
+		report.schedulesCreated++
+		fmt.Printf("  Schedule %q -> %s (%d participants)\n", gs.Name, created.ID, len(participants))
+	}
+
+	// 4. Import escalation chains as policies
+	fmt.Println("Importing escalation policies...")
+	for _, gc := range export.EscalationChains {
+		newTeamID := teamMap[gc.TeamID]
+		if newTeamID == "" {
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping escalation chain %q: team %s not found", gc.Name, gc.TeamID))
+			continue
+		}
+
+		policy := &escalation.Policy{
+			Name:   gc.Name,
+			TeamID: newTeamID,
+			Repeat: 1,
+		}
+
+		for i, gs := range gc.Steps {
+			step := escalation.Step{
+				StepOrder:      i,
+				TimeoutSeconds: gs.Duration,
+				NotifyChannel:  gs.NotifyChannel,
+			}
+			if step.NotifyChannel == "" {
+				step.NotifyChannel = "slack"
+			}
+			if step.TimeoutSeconds == 0 {
+				step.TimeoutSeconds = 300
+			}
+
+			switch gs.Type {
+			case "notify_schedule":
+				newScheduleID := scheduleMap[gs.TargetID]
+				if newScheduleID == "" {
+					report.warnings = append(report.warnings, fmt.Sprintf("escalation %q step %d: schedule %s not found", gc.Name, i, gs.TargetID))
+					continue
+				}
+				step.NotifyScheduleID = newScheduleID
+			case "notify_user":
+				newUserID := userMap[gs.TargetID]
+				if newUserID == "" {
+					report.warnings = append(report.warnings, fmt.Sprintf("escalation %q step %d: user %s not found", gc.Name, i, gs.TargetID))
+					continue
+				}
+				step.NotifyUserID = newUserID
+			default:
+				report.warnings = append(report.warnings, fmt.Sprintf("escalation %q step %d: unsupported type %q, skipping step", gc.Name, i, gs.Type))
+				continue
+			}
+
+			policy.Steps = append(policy.Steps, step)
+		}
+
+		created, err := db.CreatePolicy(ctx, policy)
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create policy %q: %v", gc.Name, err))
+			continue
+		}
+		policyMap[gc.ID] = created.ID
+		report.policiesCreated++
+		fmt.Printf("  Policy %q -> %s (%d steps)\n", gc.Name, created.ID, len(policy.Steps))
+	}
+
+	// 5. Import integrations
+	fmt.Println("Importing integrations...")
+	for _, gi := range export.Integrations {
+		newTeamID := teamMap[gi.TeamID]
+		if newTeamID == "" {
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping integration %q: team %s not found", gi.Name, gi.TeamID))
+			continue
+		}
+
+		policyID := ""
+		if gi.EscalationChainID != "" {
+			policyID = policyMap[gi.EscalationChainID]
+			if policyID == "" {
+				report.warnings = append(report.warnings, fmt.Sprintf("integration %q: escalation chain %s not found in mapping", gi.Name, gi.EscalationChainID))
+			}
+		}
+
+		intType := gi.Type
+		if intType == "" {
+			intType = "webhook"
+		}
+
+		created, err := db.CreateIntegration(ctx, gi.Name, newTeamID, intType, policyID)
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create integration %q: %v", gi.Name, err))
+			continue
+		}
+		report.integrationsCreated++
+		fmt.Printf("  Integration %q -> %s\n", gi.Name, created.ID)
+	}
+
+	report.print()
+	return nil
+}
+
+func mapGrafanaFrequency(shifts []grafanaShift) schedule.RotationType {
+	if len(shifts) == 0 {
+		return schedule.RotationWeekly
+	}
+	switch shifts[0].Frequency {
+	case "daily":
+		return schedule.RotationDaily
+	case "hourly":
+		return schedule.RotationCustom
+	default:
+		return schedule.RotationWeekly
+	}
+}

--- a/cmd/turnis/migrate_opsgenie.go
+++ b/cmd/turnis/migrate_opsgenie.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/atoolz/turnis/internal/config"
+	"github.com/atoolz/turnis/internal/escalation"
+	"github.com/atoolz/turnis/internal/schedule"
+	"github.com/atoolz/turnis/internal/store"
+)
+
+// Opsgenie API response structures.
+
+type opsgenieResponse[T any] struct {
+	Data T `json:"data"`
+}
+
+type opsgenieTeam struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type opsgenieUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	FullName string `json:"fullName"`
+	Role     struct {
+		Name string `json:"name"`
+	} `json:"role"`
+}
+
+type opsgenieSchedule struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Timezone string `json:"timezone"`
+	OwnerTeam struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"ownerTeam"`
+	Rotations []opsgenieRotation `json:"rotations"`
+}
+
+type opsgenieRotation struct {
+	ID           string               `json:"id"`
+	Name         string               `json:"name"`
+	Type         string               `json:"type"`
+	Length       int                   `json:"length"`
+	Participants []opsgenieParticipant `json:"participants"`
+}
+
+type opsgenieParticipant struct {
+	Type     string `json:"type"`
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+type opsgenieEscalation struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	OwnerTeam struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"ownerTeam"`
+	Rules []opsgenieEscalationRule `json:"rules"`
+}
+
+type opsgenieEscalationRule struct {
+	Condition  string `json:"condition"`
+	NotifyType string `json:"notifyType"`
+	Delay      struct {
+		TimeAmount int `json:"timeAmount"`
+	} `json:"delay"`
+	Recipient struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"recipient"`
+}
+
+type opsgenieIntegration struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+	OwnerTeam struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"ownerTeam"`
+}
+
+type opsgenieClient struct {
+	baseURL string
+	apiKey  string
+	httpCli *http.Client
+}
+
+func newOpsgenieClient(apiKey, region string) *opsgenieClient {
+	baseURL := "https://api.opsgenie.com"
+	if region == "eu" {
+		baseURL = "https://api.eu.opsgenie.com"
+	}
+	return &opsgenieClient{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpCli: &http.Client{},
+	}
+}
+
+func (c *opsgenieClient) get(path string, result any) error {
+	req, err := http.NewRequest("GET", c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "GenieKey "+c.apiKey)
+
+	resp, err := c.httpCli.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
+		return fmt.Errorf("parsing response: %w", err)
+	}
+	return nil
+}
+
+func migrateOpsgenieCmd() *cobra.Command {
+	var apiKey string
+	var region string
+	var dbDSN string
+
+	cmd := &cobra.Command{
+		Use:   "opsgenie",
+		Short: "Import data from Opsgenie via REST API",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if apiKey == "" {
+				return fmt.Errorf("--api-key is required")
+			}
+			return runOpsgenieMigration(apiKey, region, dbDSN)
+		},
+	}
+
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "Opsgenie API key")
+	cmd.Flags().StringVar(&region, "region", "us", "Opsgenie region (us or eu)")
+	cmd.Flags().StringVar(&dbDSN, "db", "turnis.db", "SQLite database path")
+
+	return cmd
+}
+
+func runOpsgenieMigration(apiKey, region, dbDSN string) error {
+	client := newOpsgenieClient(apiKey, region)
+
+	db, err := store.New(config.DatabaseConfig{Driver: "sqlite", DSN: dbDSN})
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Migrate(); err != nil {
+		return fmt.Errorf("running migrations: %w", err)
+	}
+
+	ctx := context.Background()
+	report := &migrationReport{}
+
+	teamMap := make(map[string]string)
+	userMap := make(map[string]string)
+	scheduleMap := make(map[string]string)
+	policyMap := make(map[string]string)
+
+	// 1. Fetch and import teams
+	fmt.Println("Fetching teams from Opsgenie...")
+	var teamsResp opsgenieResponse[[]opsgenieTeam]
+	if err := client.get("/v2/teams", &teamsResp); err != nil {
+		return fmt.Errorf("fetching teams: %w", err)
+	}
+
+	for _, ot := range teamsResp.Data {
+		team, err := db.CreateTeam(ctx, ot.Name, "")
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create team %q: %v", ot.Name, err))
+			continue
+		}
+		teamMap[ot.ID] = team.ID
+		report.teamsCreated++
+		fmt.Printf("  Team %q -> %s\n", ot.Name, team.ID)
+	}
+
+	// 2. Fetch and import users
+	fmt.Println("Fetching users from Opsgenie...")
+	var usersResp opsgenieResponse[[]opsgenieUser]
+	if err := client.get("/v2/users", &usersResp); err != nil {
+		return fmt.Errorf("fetching users: %w", err)
+	}
+
+	for _, ou := range usersResp.Data {
+		name := ou.FullName
+		if name == "" {
+			name = ou.Username
+		}
+		email := ou.Username // Opsgenie uses email as username
+		user, err := db.CreateUser(ctx, name, email, "", "", "", "")
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create user %q: %v", name, err))
+			continue
+		}
+		userMap[ou.ID] = user.ID
+		// Also map by username so we can resolve schedule participants.
+		if existing, ok := userMap[ou.Username]; ok && existing != user.ID {
+			report.warnings = append(report.warnings, fmt.Sprintf("username %q maps to multiple users; participant lookup by username may be ambiguous", ou.Username))
+		}
+		userMap[ou.Username] = user.ID
+		report.usersCreated++
+		fmt.Printf("  User %q -> %s\n", name, user.ID)
+	}
+
+	// 3. Fetch and import schedules
+	fmt.Println("Fetching schedules from Opsgenie...")
+	var schedulesResp opsgenieResponse[[]opsgenieSchedule]
+	if err := client.get("/v2/schedules", &schedulesResp); err != nil {
+		return fmt.Errorf("fetching schedules: %w", err)
+	}
+
+	for _, ogSched := range schedulesResp.Data {
+		newTeamID := teamMap[ogSched.OwnerTeam.ID]
+		if newTeamID == "" {
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping schedule %q: team %q not found in mapping", ogSched.Name, ogSched.OwnerTeam.Name))
+			report.schedulesSkipped++
+			continue
+		}
+
+		// Fetch full schedule details (includes rotations)
+		var schedDetail opsgenieResponse[opsgenieSchedule]
+		if err := client.get("/v2/schedules/"+ogSched.ID, &schedDetail); err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to fetch schedule details for %q: %v", ogSched.Name, err))
+			report.schedulesSkipped++
+			continue
+		}
+
+		detail := schedDetail.Data
+		tz := detail.Timezone
+		if tz == "" {
+			tz = "UTC"
+		}
+
+		rotationType, rotationLength := mapOpsgenieRotation(detail.Rotations)
+
+		sched := &schedule.Schedule{
+			Name:           detail.Name,
+			TeamID:         newTeamID,
+			Timezone:       tz,
+			RotationType:   rotationType,
+			RotationLength: rotationLength,
+		}
+
+		// Map each Opsgenie rotation to a Turnis layer
+		var layers []schedule.Layer
+		for priority, rot := range detail.Rotations {
+			var participants []schedule.Participant
+			for pos, p := range rot.Participants {
+				uid := resolveOpsgenieParticipant(p, userMap)
+				if uid == "" {
+					report.warnings = append(report.warnings, fmt.Sprintf("schedule %q rotation %q: participant %s not found", detail.Name, rot.Name, p.ID))
+					continue
+				}
+				participants = append(participants, schedule.Participant{
+					UserID:   uid,
+					Position: pos,
+				})
+			}
+			if len(participants) > 0 {
+				layers = append(layers, schedule.Layer{
+					Priority:     priority,
+					Participants: participants,
+				})
+			}
+		}
+		sched.Layers = layers
+
+		created, err := db.CreateSchedule(ctx, sched)
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create schedule %q: %v", detail.Name, err))
+			continue
+		}
+		scheduleMap[ogSched.ID] = created.ID
+		report.schedulesCreated++
+		fmt.Printf("  Schedule %q -> %s (%d layers)\n", detail.Name, created.ID, len(layers))
+	}
+
+	// 4. Fetch and import escalations
+	fmt.Println("Fetching escalations from Opsgenie...")
+	var escalationsResp opsgenieResponse[[]opsgenieEscalation]
+	if err := client.get("/v2/escalations", &escalationsResp); err != nil {
+		return fmt.Errorf("fetching escalations: %w", err)
+	}
+
+	for _, oe := range escalationsResp.Data {
+		newTeamID := teamMap[oe.OwnerTeam.ID]
+		if newTeamID == "" {
+			report.warnings = append(report.warnings, fmt.Sprintf("skipping escalation %q: team %q not found", oe.Name, oe.OwnerTeam.Name))
+			continue
+		}
+
+		policy := &escalation.Policy{
+			Name:   oe.Name,
+			TeamID: newTeamID,
+			Repeat: 1,
+		}
+
+		for i, rule := range oe.Rules {
+			step := escalation.Step{
+				StepOrder:      i,
+				TimeoutSeconds: rule.Delay.TimeAmount * 60, // Opsgenie delay is in minutes
+				NotifyChannel:  "slack",
+			}
+			if step.TimeoutSeconds == 0 {
+				step.TimeoutSeconds = 300
+			}
+
+			switch rule.Recipient.Type {
+			case "schedule":
+				newScheduleID := scheduleMap[rule.Recipient.ID]
+				if newScheduleID == "" {
+					report.warnings = append(report.warnings, fmt.Sprintf("escalation %q step %d: schedule %q not found", oe.Name, i, rule.Recipient.Name))
+					continue
+				}
+				step.NotifyScheduleID = newScheduleID
+			case "user":
+				newUserID := userMap[rule.Recipient.ID]
+				if newUserID == "" {
+					report.warnings = append(report.warnings, fmt.Sprintf("escalation %q step %d: user %q not found", oe.Name, i, rule.Recipient.Name))
+					continue
+				}
+				step.NotifyUserID = newUserID
+			default:
+				report.warnings = append(report.warnings, fmt.Sprintf("escalation %q step %d: unsupported recipient type %q, skipping", oe.Name, i, rule.Recipient.Type))
+				continue
+			}
+
+			policy.Steps = append(policy.Steps, step)
+		}
+
+		created, err := db.CreatePolicy(ctx, policy)
+		if err != nil {
+			report.warnings = append(report.warnings, fmt.Sprintf("failed to create policy %q: %v", oe.Name, err))
+			continue
+		}
+		policyMap[oe.ID] = created.ID
+		report.policiesCreated++
+		fmt.Printf("  Policy %q -> %s (%d steps)\n", oe.Name, created.ID, len(policy.Steps))
+	}
+
+	// 5. Fetch and import integrations
+	fmt.Println("Fetching integrations from Opsgenie...")
+	var integrationsResp opsgenieResponse[[]opsgenieIntegration]
+	if err := client.get("/v2/integrations", &integrationsResp); err != nil {
+		report.warnings = append(report.warnings, fmt.Sprintf("failed to fetch integrations: %v", err))
+	} else {
+		for _, oi := range integrationsResp.Data {
+			newTeamID := teamMap[oi.OwnerTeam.ID]
+			if newTeamID == "" {
+				report.warnings = append(report.warnings, fmt.Sprintf("skipping integration %q: team not found", oi.Name))
+				continue
+			}
+
+			// Opsgenie integrations don't directly link to escalations, leave policy empty
+			created, err := db.CreateIntegration(ctx, oi.Name, newTeamID, "webhook", "")
+			if err != nil {
+				report.warnings = append(report.warnings, fmt.Sprintf("failed to create integration %q: %v", oi.Name, err))
+				continue
+			}
+			report.integrationsCreated++
+			fmt.Printf("  Integration %q -> %s\n", oi.Name, created.ID)
+		}
+	}
+
+	report.print()
+	return nil
+}
+
+func mapOpsgenieRotation(rotations []opsgenieRotation) (schedule.RotationType, int) {
+	if len(rotations) == 0 {
+		return schedule.RotationWeekly, 1
+	}
+	rot := rotations[0]
+	length := rot.Length
+	if length == 0 {
+		length = 1
+	}
+	switch rot.Type {
+	case "daily":
+		return schedule.RotationDaily, length
+	case "hourly":
+		return schedule.RotationCustom, length
+	default:
+		return schedule.RotationWeekly, length
+	}
+}
+
+func resolveOpsgenieParticipant(p opsgenieParticipant, userMap map[string]string) string {
+	if uid := userMap[p.ID]; uid != "" {
+		return uid
+	}
+	if uid := userMap[p.Username]; uid != "" {
+		return uid
+	}
+	return ""
+}

--- a/docs/integrations/datadog.md
+++ b/docs/integrations/datadog.md
@@ -1,0 +1,211 @@
+# Datadog Integration
+
+This guide configures Datadog to send monitor alerts to Turnis via Datadog's webhook integration.
+
+## Prerequisites
+
+- A running Turnis instance with a webhook integration created (see [Getting Started](../getting-started.md#7-create-a-webhook-integration))
+- Your webhook token from the integration response
+- A Datadog account with permissions to configure integrations
+
+## Step 1: Create a webhook integration in Datadog
+
+1. In Datadog, navigate to **Integrations > Integrations** and search for **Webhooks**
+2. Click **Configure** (or **Install** if not yet installed)
+3. Scroll down to **Webhooks** and click **New**
+4. Fill in the fields:
+   - **Name**: `turnis`
+   - **URL**: `https://turnis.yourcompany.com/webhook/YOUR_WEBHOOK_TOKEN`
+   - **Payload**: paste the JSON template below
+   - **Custom Headers**: add `Content-Type: application/json`
+5. Check **Encode as form** is **unchecked** (the payload must be sent as raw JSON)
+6. Click **Save**
+
+## Step 2: Configure the payload template
+
+Paste this payload template in the **Payload** field:
+
+```json
+{
+  "title": "$ALERT_TITLE",
+  "message": "$EVENT_MSG",
+  "severity": "warning",
+  "source": "datadog",
+  "fingerprint": "dd-$ALERT_ID",
+  "labels": {
+    "alert_id": "$ALERT_ID",
+    "alert_type": "$ALERT_TYPE",
+    "alert_status": "$ALERT_STATUS",
+    "hostname": "$HOSTNAME",
+    "org_name": "$ORG_NAME",
+    "event_type": "$EVENT_TYPE",
+    "alert_query": "$ALERT_QUERY",
+    "alert_scope": "$ALERT_SCOPE",
+    "last_updated": "$LAST_UPDATED",
+    "link": "$LINK"
+  }
+}
+```
+
+### Datadog variable to Turnis field mapping
+
+| Datadog variable     | Turnis field            | Description                                             |
+|----------------------|-------------------------|---------------------------------------------------------|
+| `$ALERT_TITLE`       | `title`                 | Monitor name and triggering scope                       |
+| `$EVENT_MSG`         | `message`               | Monitor message body (supports markdown from Datadog)   |
+| `$ALERT_PRIORITY`    | `severity`              | Maps to Turnis severity (see mapping table below)       |
+| `$ALERT_ID`          | `fingerprint` (prefix)  | Unique monitor ID, prefixed with `dd-` for namespacing  |
+| `$ALERT_TYPE`        | `labels.alert_type`     | `error`, `warning`, `info`, or `success`                |
+| `$ALERT_STATUS`      | `labels.alert_status`   | `Triggered`, `Recovered`, `No Data`, etc.               |
+| `$HOSTNAME`          | `labels.hostname`       | Host that triggered the alert                           |
+| `$ORG_NAME`          | `labels.org_name`       | Your Datadog organization name                          |
+| `$EVENT_TYPE`        | `labels.event_type`     | Event type string                                       |
+| `$ALERT_QUERY`       | `labels.alert_query`    | The monitor query that triggered                        |
+| `$ALERT_SCOPE`       | `labels.alert_scope`    | Scope tags (e.g., `host:web-01,env:prod`)               |
+| `$LAST_UPDATED`      | `labels.last_updated`   | Timestamp of the last status change                     |
+| `$LINK`              | `labels.link`           | Direct link to the Datadog monitor                      |
+
+### Severity mapping
+
+Datadog's `$ALERT_PRIORITY` returns a value like `P1`, `P2`, `P3`, `P4`, or `normal`. Turnis accepts `critical`, `warning`, and `info`. To handle this, use a conditional payload or accept the Datadog value as-is in the labels and set a fixed severity.
+
+**Option A: Fixed severity with priority in labels (simplest)**
+
+```json
+{
+  "title": "$ALERT_TITLE",
+  "message": "$EVENT_MSG",
+  "severity": "critical",
+  "source": "datadog",
+  "fingerprint": "dd-$ALERT_ID",
+  "labels": {
+    "priority": "$ALERT_PRIORITY",
+    "alert_type": "$ALERT_TYPE",
+    "hostname": "$HOSTNAME",
+    "link": "$LINK"
+  }
+}
+```
+
+**Option B: Map severity via Datadog conditional variables**
+
+Datadog supports conditional formatting in webhook payloads. Use `$ALERT_TYPE` which returns `error`, `warning`, `info`, or `success`:
+
+```json
+{
+  "title": "$ALERT_TITLE",
+  "message": "$EVENT_MSG",
+  "severity": "$ALERT_TYPE",
+  "source": "datadog",
+  "fingerprint": "dd-$ALERT_ID",
+  "labels": {
+    "hostname": "$HOSTNAME",
+    "alert_scope": "$ALERT_SCOPE",
+    "link": "$LINK"
+  }
+}
+```
+
+Turnis treats unrecognized severity values as `info`, so `$ALERT_TYPE` values of `error` and `success` both default to `info`. For the most accurate mapping, use Option A and set the severity explicitly based on the monitor's importance.
+
+**Option C: Use different webhooks per severity**
+
+Create multiple webhook integrations in both Datadog and Turnis:
+
+- `turnis-critical` for P1/P2 monitors
+- `turnis-warning` for P3 monitors
+- `turnis-info` for P4+ monitors
+
+Each points to a different Turnis integration with appropriate escalation policies.
+
+## Step 3: Attach the webhook to monitors
+
+For each Datadog monitor that should page via Turnis:
+
+1. Open the monitor and click **Edit**
+2. In the **Notify your team** section, add `@webhook-turnis` in the message body
+3. Click **Save**
+
+Example monitor message:
+
+```
+CPU usage on {{host.name}} exceeded threshold.
+
+Current value: {{value}}
+Threshold: {{threshold}}
+
+Runbook: https://wiki.example.com/runbooks/high-cpu
+
+@webhook-turnis
+```
+
+To apply to all monitors of a certain type, use Datadog's **Manage Monitors** page to bulk-edit the notification recipients.
+
+## Example: what Datadog sends to Turnis
+
+After variable substitution, Turnis receives a payload like this:
+
+```json
+{
+  "title": "[Triggered] High CPU on web-01",
+  "message": "CPU usage on web-01 exceeded threshold.\n\nCurrent value: 94.5%\nThreshold: 90%\n\nRunbook: https://wiki.example.com/runbooks/high-cpu",
+  "severity": "critical",
+  "source": "datadog",
+  "fingerprint": "dd-12345678",
+  "labels": {
+    "alert_id": "12345678",
+    "alert_type": "error",
+    "alert_status": "Triggered",
+    "hostname": "web-01",
+    "org_name": "MyCompany",
+    "event_type": "metric_alert_monitor",
+    "alert_query": "avg(last_5m):avg:system.cpu.user{host:web-01} > 90",
+    "alert_scope": "host:web-01",
+    "last_updated": "1711375200",
+    "link": "https://app.datadoghq.com/monitors/12345678"
+  }
+}
+```
+
+## Handling resolved alerts
+
+Datadog sends the webhook again when a monitor recovers, with `$ALERT_STATUS` set to `Recovered` and `$ALERT_TYPE` set to `success`. Because the fingerprint (`dd-$ALERT_ID`) remains the same, Turnis will deduplicate the recovery notification against the active alert. The original alert stays in its current state.
+
+To resolve alerts in Turnis when Datadog recovers them, you have two options:
+
+1. **Manual resolution**: Resolve via Turnis Slack, web UI, or REST API
+2. **Automated resolution**: Deploy a small adapter that calls the Turnis resolve endpoint when it receives a Datadog recovery webhook. See the adapter pattern in the [Prometheus Alertmanager guide](prometheus-alertmanager.md).
+
+## Verifying the integration
+
+1. In Datadog, go to **Integrations > Webhooks** and find your `turnis` webhook
+2. Click **Test** to send a test payload
+3. Check Turnis for the test alert:
+
+```bash
+curl -s https://turnis.yourcompany.com/api/v1/alerts | jq
+```
+
+4. To test with a real monitor, create a monitor with a low threshold that will trigger immediately, add `@webhook-turnis` to its message, and wait for it to fire.
+
+## All available Datadog variables
+
+For reference, these are all the variables you can use in the webhook payload template:
+
+| Variable           | Description                                      |
+|--------------------|--------------------------------------------------|
+| `$ALERT_ID`        | Unique ID of the monitor                         |
+| `$ALERT_TITLE`     | Monitor title with triggering context             |
+| `$ALERT_TYPE`      | `error`, `warning`, `info`, or `success`         |
+| `$ALERT_STATUS`    | `Triggered`, `Recovered`, `No Data`, etc.        |
+| `$ALERT_QUERY`     | The monitor query                                |
+| `$ALERT_SCOPE`     | Comma-separated scope tags                       |
+| `$ALERT_PRIORITY`  | Priority (`P1`, `P2`, `P3`, `P4`, `normal`)     |
+| `$EVENT_MSG`       | Monitor message body                             |
+| `$EVENT_TYPE`      | Event type identifier                            |
+| `$HOSTNAME`        | Host that triggered the alert                    |
+| `$ORG_NAME`        | Datadog organization name                        |
+| `$LAST_UPDATED`    | Unix timestamp of last status change             |
+| `$LINK`            | URL to the monitor in Datadog                    |
+| `$SNAPSHOT`         | URL to a graph snapshot (if applicable)          |
+| `$TAGS`            | Comma-separated list of tags                     |

--- a/docs/integrations/generic-webhook.md
+++ b/docs/integrations/generic-webhook.md
@@ -1,0 +1,222 @@
+# Generic Webhook Integration
+
+This document covers the full ingest payload schema, deduplication behavior, and examples for sending alerts to Turnis via its webhook endpoint.
+
+## Webhook URL
+
+Every integration you create in Turnis gets a unique token. The webhook endpoint is:
+
+```
+POST https://turnis.yourcompany.com/webhook/<token>
+```
+
+Replace `<token>` with the token returned when you created the integration (see [Getting Started](../getting-started.md#7-create-a-webhook-integration)).
+
+## Payload Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Turnis Incoming Alert",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "Short summary of the alert. This is the only required field."
+    },
+    "message": {
+      "type": "string",
+      "description": "Longer description, runbook link, or any additional context."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["info", "warning", "critical"],
+      "default": "info",
+      "description": "Alert severity level."
+    },
+    "source": {
+      "type": "string",
+      "description": "Name of the system that generated the alert (e.g. 'prometheus', 'grafana', 'datadog')."
+    },
+    "fingerprint": {
+      "type": "string",
+      "description": "Stable identifier for deduplication. Alerts with the same fingerprint and integration are grouped."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Arbitrary key-value pairs attached to the alert."
+    }
+  },
+  "additionalProperties": true
+}
+```
+
+### Field Summary
+
+| Field         | Type              | Required | Default  | Description                                          |
+|---------------|-------------------|----------|----------|------------------------------------------------------|
+| `title`       | string            | Yes      |          | Short summary of the alert                           |
+| `message`     | string            | No       | `""`     | Extended description or runbook link                 |
+| `severity`    | string            | No       | `"info"` | One of `info`, `warning`, `critical`                 |
+| `source`      | string            | No       | `""`     | Origin system name                                   |
+| `fingerprint` | string            | No       | `""`     | Stable ID for deduplication (see below)              |
+| `labels`      | map[string]string | No       | `{}`     | Arbitrary metadata key-value pairs                   |
+
+## Deduplication via Fingerprint
+
+When you include a `fingerprint` in the payload, Turnis checks whether any non-resolved alert with the same fingerprint already exists for that integration.
+
+- If a match is found, Turnis returns the existing alert with `"deduplicated": true` and HTTP status `200 OK`. No new alert is created.
+- If no match is found, Turnis creates a new alert and returns it with HTTP status `201 Created`.
+
+This means you can safely call the webhook on every evaluation cycle of your monitoring tool without generating duplicate alerts. As long as the fingerprint stays the same, subsequent calls are no-ops.
+
+Fingerprint values are scoped to the integration. Two different integrations can use the same fingerprint string without conflicting.
+
+## Examples
+
+### Fire an alert
+
+```bash
+curl -s -X POST "https://turnis.yourcompany.com/webhook/$WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "High CPU on api-server-01",
+    "message": "CPU usage exceeded 90% for 5 minutes. Runbook: https://wiki.example.com/runbooks/high-cpu",
+    "severity": "critical",
+    "source": "prometheus",
+    "fingerprint": "cpu-high-api-server-01",
+    "labels": {
+      "env": "production",
+      "service": "api",
+      "host": "api-server-01"
+    }
+  }' | jq
+```
+
+Response (`201 Created`):
+
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "integration_id": "int-abcdef12",
+  "fingerprint": "cpu-high-api-server-01",
+  "status": "firing",
+  "title": "High CPU on api-server-01",
+  "message": "CPU usage exceeded 90% for 5 minutes. Runbook: https://wiki.example.com/runbooks/high-cpu",
+  "severity": "critical",
+  "source": "prometheus",
+  "created_at": "2026-03-25T14:30:00Z",
+  "updated_at": "2026-03-25T14:30:00Z"
+}
+```
+
+### Fire a duplicate (deduplication in action)
+
+Sending the same fingerprint while the alert is still active:
+
+```bash
+curl -s -X POST "https://turnis.yourcompany.com/webhook/$WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "High CPU on api-server-01",
+    "severity": "critical",
+    "fingerprint": "cpu-high-api-server-01"
+  }' | jq
+```
+
+Response (`200 OK`):
+
+```json
+{
+  "deduplicated": true,
+  "alert": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "integration_id": "int-abcdef12",
+    "fingerprint": "cpu-high-api-server-01",
+    "status": "firing",
+    "title": "High CPU on api-server-01",
+    "severity": "critical",
+    "source": "prometheus",
+    "created_at": "2026-03-25T14:30:00Z",
+    "updated_at": "2026-03-25T14:30:00Z"
+  }
+}
+```
+
+### Acknowledge an alert
+
+Acknowledgment is done via the REST API, not the webhook endpoint:
+
+```bash
+curl -s -X POST "https://turnis.yourcompany.com/api/v1/alerts/$ALERT_ID/ack" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "usr-alice-id"}' | jq
+```
+
+Response (`200 OK`):
+
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "integration_id": "int-abcdef12",
+  "fingerprint": "cpu-high-api-server-01",
+  "status": "acknowledged",
+  "title": "High CPU on api-server-01",
+  "severity": "critical",
+  "acknowledged_by": "usr-alice-id",
+  "acknowledged_at": "2026-03-25T14:35:00Z",
+  "created_at": "2026-03-25T14:30:00Z",
+  "updated_at": "2026-03-25T14:35:00Z"
+}
+```
+
+### Resolve an alert
+
+```bash
+curl -s -X POST "https://turnis.yourcompany.com/api/v1/alerts/$ALERT_ID/resolve" | jq
+```
+
+Response (`200 OK`):
+
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "integration_id": "int-abcdef12",
+  "fingerprint": "cpu-high-api-server-01",
+  "status": "resolved",
+  "title": "High CPU on api-server-01",
+  "severity": "critical",
+  "acknowledged_by": "usr-alice-id",
+  "acknowledged_at": "2026-03-25T14:35:00Z",
+  "resolved_at": "2026-03-25T14:40:00Z",
+  "created_at": "2026-03-25T14:30:00Z",
+  "updated_at": "2026-03-25T14:40:00Z"
+}
+```
+
+### Minimal alert (title only)
+
+```bash
+curl -s -X POST "https://turnis.yourcompany.com/webhook/$WEBHOOK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Something broke"}' | jq
+```
+
+This creates a new alert every time it is called because there is no fingerprint for deduplication.
+
+## Error Responses
+
+All errors return a JSON object with an `error` field:
+
+| HTTP Status | Meaning                                  | Example                                 |
+|-------------|------------------------------------------|-----------------------------------------|
+| `400`       | Invalid JSON or missing required fields  | `{"error": "title is required"}`        |
+| `401`       | Missing or invalid webhook token         | `{"error": "invalid webhook token"}`    |
+| `500`       | Internal server error                    | `{"error": "failed to create alert"}`   |
+
+## Content-Type
+
+The webhook endpoint expects `Content-Type: application/json`. Requests with other content types will return a `400 Bad Request`.

--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -1,0 +1,180 @@
+# Grafana Integration
+
+This guide configures Grafana Alerting to send alerts to Turnis via a webhook contact point.
+
+## Prerequisites
+
+- A running Turnis instance with a webhook integration created (see [Getting Started](../getting-started.md#7-create-a-webhook-integration))
+- Your webhook token from the integration response
+- Grafana 9.0+ with Grafana Alerting enabled (the default since Grafana 9)
+
+## Step 1: Create a contact point
+
+1. Open Grafana and navigate to **Alerting > Contact points**
+2. Click **Add contact point**
+3. Set the **Name** to `Turnis`
+4. Under **Integration**, select **Webhook**
+5. Set the **URL** to:
+   ```
+   https://turnis.yourcompany.com/webhook/YOUR_WEBHOOK_TOKEN
+   ```
+6. Set **HTTP Method** to `POST`
+7. Leave **Authorization Header** empty (the token in the URL is the authentication)
+8. Expand **Optional Webhook settings**:
+   - Set **Max Alerts** to `0` (no limit)
+   - Leave **Username** and **Password** empty
+9. Click **Test** to send a test notification, then **Save contact point**
+
+## Step 2: Configure the message template
+
+Grafana's default webhook payload does not match the Turnis schema. You need a custom message template that transforms the Grafana payload into Turnis format.
+
+1. Navigate to **Alerting > Contact points > Message templates**
+2. Click **Add message template**
+3. Set the **Name** to `turnis`
+4. Paste this template:
+
+```go
+{{ define "turnis" }}
+{
+  "title": "{{ (index .Alerts 0).Labels.alertname }}",
+  "message": "{{ (index .Alerts 0).Annotations.description }}",
+  "severity": "{{ if eq (index .Alerts 0).Labels.severity "critical" }}critical{{ else if eq (index .Alerts 0).Labels.severity "warning" }}warning{{ else }}info{{ end }}",
+  "source": "grafana",
+  "fingerprint": "{{ (index .Alerts 0).Fingerprint }}",
+  "labels": {
+    {{ range $i, $k := (index .Alerts 0).Labels.SortedPairs }}{{ if $i }},{{ end }}"{{ $k.Name }}": "{{ $k.Value }}"{{ end }}
+  }
+}
+{{ end }}
+```
+
+5. Click **Save**
+
+6. Go back to your `Turnis` contact point and set the **Message** field to use the template:
+   - In **Optional Webhook settings**, find the **Body** field
+   - Set it to: `{{ template "turnis" . }}`
+
+Alternatively, if your Grafana version supports the **Custom body** field directly in the webhook contact point settings, paste the template content there.
+
+## Step 3: Set up a notification policy
+
+1. Navigate to **Alerting > Notification policies**
+2. Either edit the default policy or create a new one:
+   - Click **New nested policy** (or **Edit** on the default)
+   - Under **Contact point**, select `Turnis`
+   - Optionally add matchers to route only specific alerts (e.g., `severity = critical`)
+3. Click **Save policy**
+
+## What Grafana sends (default payload)
+
+Without a custom template, Grafana sends a payload like this to webhook contact points:
+
+```json
+{
+  "receiver": "turnis",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "HighMemoryUsage",
+        "severity": "critical",
+        "instance": "web-01",
+        "grafana_folder": "Infrastructure"
+      },
+      "annotations": {
+        "description": "Memory usage on web-01 is above 95% for 10 minutes.",
+        "summary": "High memory on web-01",
+        "runbook_url": "https://wiki.example.com/runbooks/high-memory"
+      },
+      "startsAt": "2026-03-25T14:00:00Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "https://grafana.example.com/alerting/grafana/abc123/view",
+      "fingerprint": "a1b2c3d4e5f6",
+      "silenceURL": "https://grafana.example.com/alerting/silence/new?...",
+      "dashboardURL": "https://grafana.example.com/d/abc123",
+      "panelURL": "https://grafana.example.com/d/abc123?viewPanel=1",
+      "values": {
+        "B": 97.3
+      }
+    }
+  ],
+  "groupLabels": {
+    "alertname": "HighMemoryUsage"
+  },
+  "commonLabels": {
+    "alertname": "HighMemoryUsage",
+    "severity": "critical"
+  },
+  "commonAnnotations": {
+    "description": "Memory usage on web-01 is above 95% for 10 minutes."
+  },
+  "externalURL": "https://grafana.example.com",
+  "version": "1",
+  "groupKey": "{}:{alertname=\"HighMemoryUsage\"}",
+  "truncatedAlerts": 0,
+  "title": "[FIRING:1] HighMemoryUsage critical",
+  "state": "alerting",
+  "message": "**Firing**\n\nValue: B=97.3\nLabels:\n - alertname = HighMemoryUsage\n..."
+}
+```
+
+## What Turnis receives (after template transformation)
+
+After applying the `turnis` message template, the payload sent to Turnis looks like:
+
+```json
+{
+  "title": "HighMemoryUsage",
+  "message": "Memory usage on web-01 is above 95% for 10 minutes.",
+  "severity": "critical",
+  "source": "grafana",
+  "fingerprint": "a1b2c3d4e5f6",
+  "labels": {
+    "alertname": "HighMemoryUsage",
+    "grafana_folder": "Infrastructure",
+    "instance": "web-01",
+    "severity": "critical"
+  }
+}
+```
+
+## Alternative: Grafana with an HTTP adapter
+
+If you prefer not to use Grafana message templates, you can use the same adapter pattern described in the [Prometheus Alertmanager guide](prometheus-alertmanager.md). The Grafana webhook payload is very similar to Alertmanager's payload because Grafana Alerting is built on the same alert model.
+
+## Field mapping reference
+
+| Grafana field                  | Turnis field    | Notes                                                  |
+|--------------------------------|-----------------|--------------------------------------------------------|
+| `alerts[].labels.alertname`    | `title`         | Alert rule name becomes the title                      |
+| `alerts[].annotations.description` | `message`   | Description annotation becomes the message             |
+| `alerts[].labels.severity`     | `severity`      | Mapped to `info`, `warning`, or `critical`             |
+| `alerts[].fingerprint`        | `fingerprint`   | Grafana's auto-generated fingerprint, used as-is       |
+| All `alerts[].labels`          | `labels`        | Passed through as key-value pairs                      |
+| (hardcoded)                    | `source`        | Set to `"grafana"` by the template                     |
+
+## Verifying the integration
+
+1. In Grafana, go to your `Turnis` contact point and click **Test**
+2. Check Turnis for the test alert:
+
+```bash
+curl -s http://localhost:8080/api/v1/alerts | jq
+```
+
+3. To test with a real alert, create a simple alert rule:
+   - Navigate to **Alerting > Alert rules > New alert rule**
+   - Create a rule that evaluates to `true` (e.g., a static threshold below a known value)
+   - Assign it to the notification policy that routes to `Turnis`
+   - Wait for the evaluation interval and check Turnis for the alert
+
+## Grafana OnCall migration note
+
+If you are migrating from Grafana OnCall (archived in 2024), the main changes are:
+
+- Replace the OnCall integration URL with the Turnis webhook URL
+- OnCall's auto-acknowledge and auto-resolve features are handled by Turnis via fingerprint-based deduplication and the REST API ack/resolve endpoints
+- Escalation policies are configured in Turnis, not in Grafana
+- On-call schedules live in Turnis, not in the Grafana OnCall plugin

--- a/docs/integrations/prometheus-alertmanager.md
+++ b/docs/integrations/prometheus-alertmanager.md
@@ -1,0 +1,325 @@
+# Prometheus Alertmanager Integration
+
+This guide configures Alertmanager to send alerts to Turnis via its webhook endpoint.
+
+## Prerequisites
+
+- A running Turnis instance with a webhook integration created (see [Getting Started](../getting-started.md#7-create-a-webhook-integration))
+- Your webhook token from the integration response
+- Prometheus Alertmanager v0.20+
+
+## Configure Alertmanager
+
+Alertmanager's native payload format is a nested structure that Turnis does not parse directly. You need a lightweight adapter (shown below) to transform Alertmanager payloads into Turnis's flat webhook format.
+
+### Option 1: With adapter (recommended)
+
+The adapter runs as a sidecar or separate container. See the full adapter code and Docker Compose example below.
+
+### Option 2: Direct webhook (requires custom template)
+
+If you prefer no adapter, configure Alertmanager with a custom `webhook_configs` template. Note: the default Alertmanager webhook payload will NOT work without a template that transforms it.
+
+### Full alertmanager.yml example (with adapter)
+
+```yaml
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: turnis
+  group_by: ['alertname', 'instance']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+  routes:
+    # Critical alerts go to Turnis immediately
+    - match:
+        severity: critical
+      receiver: turnis
+      group_wait: 10s
+      repeat_interval: 1h
+
+    # Warning alerts go to Turnis with default timing
+    - match:
+        severity: warning
+      receiver: turnis
+
+receivers:
+  - name: turnis
+    webhook_configs:
+      - url: 'https://turnis.yourcompany.com/webhook/YOUR_WEBHOOK_TOKEN'
+        send_resolved: false
+        max_alerts: 0
+```
+
+Replace `YOUR_WEBHOOK_TOKEN` with the token from your Turnis integration.
+
+**`send_resolved: false`** is recommended because Alertmanager's resolve payload does not map cleanly to a new Turnis alert. Resolve alerts through Turnis directly (via Slack, the web UI, or the REST API).
+
+If you set `send_resolved: true`, Alertmanager will fire another webhook when the alert resolves. Turnis will deduplicate it if the fingerprint matches an active alert, but it will not auto-resolve the existing alert.
+
+## How the payload mapping works
+
+Alertmanager sends a JSON payload with a list of alerts. Each alert contains `labels`, `annotations`, `status`, `startsAt`, and other fields. Turnis does not parse the native Alertmanager format directly. You need a small adapter, or you can use Alertmanager's built-in templating via `webhook_configs` with a custom HTTP body.
+
+However, the simplest approach is to use an Alertmanager webhook receiver with a **custom template** that transforms the payload into Turnis format.
+
+### Option 1: Use alertmanager-webhook-adapter (recommended)
+
+Deploy a lightweight adapter that translates Alertmanager's native payload into Turnis format. Here is a minimal adapter using a shell script and `socat`, or use any HTTP proxy that can transform JSON.
+
+A more practical approach: use Alertmanager's `webhook_configs` with an intermediate proxy. But the easiest path is configuring your alerts with clear labels and using the mapping table below.
+
+### Option 2: Direct integration with label conventions
+
+Turnis accepts any JSON that matches the [generic webhook schema](generic-webhook.md). The key is to construct a fingerprint that Alertmanager sends consistently. Alertmanager already generates a fingerprint for each alert group, but it sends the native format.
+
+The recommended approach is to place a thin HTTP adapter between Alertmanager and Turnis. Here is a complete example using a Go adapter:
+
+```go
+// cmd/am-turnis-adapter/main.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type alertmanagerPayload struct {
+	Alerts []amAlert `json:"alerts"`
+}
+
+type amAlert struct {
+	Status      string            `json:"status"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	Fingerprint string            `json:"fingerprint"`
+}
+
+type turnisAlert struct {
+	Title       string            `json:"title"`
+	Message     string            `json:"message,omitempty"`
+	Severity    string            `json:"severity,omitempty"`
+	Source      string            `json:"source"`
+	Fingerprint string            `json:"fingerprint"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+func main() {
+	turnisURL := os.Getenv("TURNIS_WEBHOOK_URL")
+	if turnisURL == "" {
+		log.Fatal("TURNIS_WEBHOOK_URL is required")
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var payload alertmanagerPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		for _, a := range payload.Alerts {
+			if a.Status == "resolved" {
+				continue // skip resolved, handle via Turnis directly
+			}
+
+			ta := turnisAlert{
+				Title:       a.Labels["alertname"],
+				Message:     a.Annotations["description"],
+				Severity:    mapSeverity(a.Labels["severity"]),
+				Source:      "prometheus",
+				Fingerprint: a.Fingerprint,
+				Labels:      a.Labels,
+			}
+
+			body, _ := json.Marshal(ta)
+			resp, err := http.Post(turnisURL, "application/json", bytes.NewReader(body))
+			if err != nil {
+				log.Printf("failed to forward alert: %v", err)
+				continue
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			log.Printf("forwarded alert=%s status=%d", a.Labels["alertname"], resp.StatusCode)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	addr := ":9097"
+	log.Printf("listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func mapSeverity(s string) string {
+	switch strings.ToLower(s) {
+	case "critical", "error", "fatal":
+		return "critical"
+	case "warning", "warn":
+		return "warning"
+	default:
+		return "info"
+	}
+}
+```
+
+Build and run:
+
+```bash
+go build -o am-turnis-adapter ./cmd/am-turnis-adapter
+TURNIS_WEBHOOK_URL=https://turnis.yourcompany.com/webhook/YOUR_WEBHOOK_TOKEN ./am-turnis-adapter
+```
+
+Then point Alertmanager at the adapter instead of Turnis directly:
+
+```yaml
+receivers:
+  - name: turnis
+    webhook_configs:
+      - url: 'http://am-turnis-adapter:9097'
+        send_resolved: false
+```
+
+### Label to Turnis field mapping
+
+| Alertmanager field             | Turnis field    | Notes                                                     |
+|--------------------------------|-----------------|-----------------------------------------------------------|
+| `labels.alertname`             | `title`         | Alert name becomes the title                              |
+| `annotations.description`     | `message`       | Long description or runbook link                          |
+| `labels.severity`             | `severity`      | Mapped to `info`, `warning`, or `critical`                |
+| `fingerprint`                 | `fingerprint`   | Alertmanager's auto-generated fingerprint, used as-is     |
+| All `labels`                  | `labels`        | Passed through as key-value pairs                         |
+| (hardcoded)                   | `source`        | Set to `"prometheus"` by the adapter                      |
+
+## What Alertmanager sends (native format)
+
+For reference, here is the JSON payload Alertmanager sends to webhook receivers:
+
+```json
+{
+  "version": "4",
+  "groupKey": "{}:{alertname=\"HighCPU\", instance=\"api-server-01:9090\"}",
+  "truncatedAlerts": 0,
+  "status": "firing",
+  "receiver": "turnis",
+  "groupLabels": {
+    "alertname": "HighCPU",
+    "instance": "api-server-01:9090"
+  },
+  "commonLabels": {
+    "alertname": "HighCPU",
+    "severity": "critical",
+    "instance": "api-server-01:9090",
+    "job": "node-exporter"
+  },
+  "commonAnnotations": {
+    "description": "CPU usage on api-server-01 exceeded 90% for 5 minutes.",
+    "summary": "High CPU on api-server-01"
+  },
+  "externalURL": "http://alertmanager.example.com",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "HighCPU",
+        "severity": "critical",
+        "instance": "api-server-01:9090",
+        "job": "node-exporter"
+      },
+      "annotations": {
+        "description": "CPU usage on api-server-01 exceeded 90% for 5 minutes.",
+        "summary": "High CPU on api-server-01"
+      },
+      "startsAt": "2026-03-25T14:20:00.000Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "http://prometheus.example.com/graph?g0.expr=...",
+      "fingerprint": "e6b04b7cc3b97b2a"
+    }
+  ]
+}
+```
+
+After the adapter transforms it, Turnis receives:
+
+```json
+{
+  "title": "HighCPU",
+  "message": "CPU usage on api-server-01 exceeded 90% for 5 minutes.",
+  "severity": "critical",
+  "source": "prometheus",
+  "fingerprint": "e6b04b7cc3b97b2a",
+  "labels": {
+    "alertname": "HighCPU",
+    "severity": "critical",
+    "instance": "api-server-01:9090",
+    "job": "node-exporter"
+  }
+}
+```
+
+## Docker Compose example with the adapter
+
+```yaml
+services:
+  turnis:
+    image: ghcr.io/atoolz/turnis:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - turnis-data:/data
+    environment:
+      TURNIS_DATABASE_DSN: /data/turnis.db
+      TURNIS_SERVER_BASE_URL: https://turnis.yourcompany.com
+
+  am-turnis-adapter:
+    build: ./cmd/am-turnis-adapter
+    environment:
+      TURNIS_WEBHOOK_URL: http://turnis:8080/webhook/YOUR_WEBHOOK_TOKEN
+    ports:
+      - "9097:9097"
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    ports:
+      - "9093:9093"
+
+volumes:
+  turnis-data:
+```
+
+## Verifying the integration
+
+1. Create a test alert in Prometheus or fire one manually via the Alertmanager API:
+
+```bash
+curl -s -X POST http://localhost:9093/api/v2/alerts \
+  -H "Content-Type: application/json" \
+  -d '[{
+    "labels": {
+      "alertname": "TestAlert",
+      "severity": "warning",
+      "instance": "test-server:9090"
+    },
+    "annotations": {
+      "description": "This is a test alert from Alertmanager."
+    }
+  }]'
+```
+
+2. Check Turnis for the new alert:
+
+```bash
+curl -s http://localhost:8080/api/v1/alerts | jq
+```
+
+You should see an alert with `title: "TestAlert"` and `source: "prometheus"`.


### PR DESCRIPTION
## Summary

Complete v0.5.0 milestone in a single PR:

- **Migration importers**: `turnis migrate grafana-oncall` and `turnis migrate opsgenie`
- **Helm chart**: full Kubernetes deployment with configmap, secret, PVC, ingress
- **Package registries**: Homebrew tap + deb/rpm via goreleaser nfpm
- **Integration guides**: Prometheus, Grafana, Datadog, generic webhook

## Code review

3 parallel reviews, 10 issues found and fixed:
- Webhook tokens removed from migration stdout output (security)
- Empty email guard in Grafana importer
- Opsgenie userMap collision warning
- Helm: added slack.appToken, email.*, log.level to chart
- Goreleaser: added brews + nfpms sections
- Docs: fixed additionalProperties, dedup description, Datadog severity mapping, Alertmanager adapter warning

## Test plan

- [x] `go build ./cmd/turnis` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Manual: `turnis migrate grafana-oncall --input test.json`
- [ ] Manual: `helm template charts/turnis` renders valid YAML

Closes #21, closes #22, closes #23, closes #24, closes #25