### PR TITLE
Implement API auth, structured audit logging, and Prometheus metrics

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/atoolz/turnis/internal/store"
 )
@@ -21,12 +23,6 @@ const apiKeyContextKey contextKey = "api_key"
 func APIKeyAuth(db *store.DB) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Exempt /api/v1/status from authentication.
-			if r.URL.Path == "/api/v1/status" {
-				next.ServeHTTP(w, r)
-				return
-			}
-
 			header := r.Header.Get("Authorization")
 			if header == "" || !strings.HasPrefix(header, "Bearer ") {
 				writeError(w, http.StatusUnauthorized, "missing or invalid Authorization header")
@@ -49,13 +45,17 @@ func APIKeyAuth(db *store.DB) func(http.Handler) http.Handler {
 			}
 
 			// Update last_used_at in the background to avoid adding latency.
+			// Use a detached context since the request context is cancelled after the handler returns.
 			go func() {
-				if err := db.UpdateAPIKeyLastUsed(r.Context(), key.ID); err != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if err := db.UpdateAPIKeyLastUsed(ctx, key.ID); err != nil {
 					slog.Error("failed to update api key last_used_at", "error", err, "key_id", key.ID)
 				}
 			}()
 
-			next.ServeHTTP(w, r)
+			ctx := context.WithValue(r.Context(), apiKeyContextKey, key)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/internal/api/integrations.go
+++ b/internal/api/integrations.go
@@ -53,6 +53,12 @@ func createIntegrationHandler(db *store.DB) http.HandlerFunc {
 			return
 		}
 
+		if auditErr := db.RecordAudit(r.Context(), "", "integration.created", "integration", integration.ID, map[string]string{
+			"name": integration.Name,
+		}); auditErr != nil {
+			slog.Error("failed to record audit for integration creation", "error", auditErr)
+		}
+
 		writeJSON(w, http.StatusCreated, integration)
 	}
 }
@@ -65,6 +71,10 @@ func deleteIntegrationHandler(db *store.DB) http.HandlerFunc {
 			slog.Error("failed to delete integration", "error", err, "integration_id", integrationID)
 			writeError(w, http.StatusNotFound, "integration not found")
 			return
+		}
+
+		if auditErr := db.RecordAudit(r.Context(), "", "integration.deleted", "integration", integrationID, nil); auditErr != nil {
+			slog.Error("failed to record audit for integration deletion", "error", auditErr)
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -26,14 +26,17 @@ func NewRouter(db *store.DB, cfg *config.Config, engine *escalation.Engine, slac
 	r.Use(middleware.Heartbeat("/healthz"))
 
 	// Prometheus metrics endpoint, outside auth middleware.
+	// If exposing Turnis publicly, protect /metrics at the network level.
 	r.Handle("/metrics", promhttp.Handler())
 
 	// Readiness probe: pings the database.
 	r.Get("/readyz", readyzHandler(db))
 
+	// Status endpoint outside auth for health checks.
+	r.Get("/api/v1/status", statusHandler)
+
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(APIKeyAuth(db))
-		r.Get("/status", statusHandler)
 
 		r.Route("/teams", func(r chi.Router) {
 			r.Get("/", listTeamsHandler(db))

--- a/internal/api/teams.go
+++ b/internal/api/teams.go
@@ -47,6 +47,12 @@ func createTeamHandler(db *store.DB) http.HandlerFunc {
 			return
 		}
 
+		if auditErr := db.RecordAudit(r.Context(), "", "team.created", "team", team.ID, map[string]string{
+			"name": team.Name,
+		}); auditErr != nil {
+			slog.Error("failed to record audit for team creation", "error", auditErr)
+		}
+
 		writeJSON(w, http.StatusCreated, team)
 	}
 }
@@ -74,6 +80,10 @@ func deleteTeamHandler(db *store.DB) http.HandlerFunc {
 			slog.Error("failed to delete team", "error", err, "team_id", teamID)
 			writeError(w, http.StatusNotFound, "team not found")
 			return
+		}
+
+		if auditErr := db.RecordAudit(r.Context(), "", "team.deleted", "team", teamID, nil); auditErr != nil {
+			slog.Error("failed to record audit for team deletion", "error", auditErr)
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -57,6 +57,13 @@ func createUserHandler(db *store.DB) http.HandlerFunc {
 			return
 		}
 
+		if auditErr := db.RecordAudit(r.Context(), "", "user.created", "user", user.ID, map[string]string{
+			"name":  user.Name,
+			"email": user.Email,
+		}); auditErr != nil {
+			slog.Error("failed to record audit for user creation", "error", auditErr)
+		}
+
 		writeJSON(w, http.StatusCreated, user)
 	}
 }
@@ -108,6 +115,13 @@ func updateUserHandler(db *store.DB) http.HandlerFunc {
 			return
 		}
 
+		if auditErr := db.RecordAudit(r.Context(), "", "user.updated", "user", userID, map[string]string{
+			"name":  user.Name,
+			"email": user.Email,
+		}); auditErr != nil {
+			slog.Error("failed to record audit for user update", "error", auditErr)
+		}
+
 		writeJSON(w, http.StatusOK, user)
 	}
 }
@@ -120,6 +134,10 @@ func deleteUserHandler(db *store.DB) http.HandlerFunc {
 			slog.Error("failed to delete user", "error", err, "user_id", userID)
 			writeError(w, http.StatusNotFound, "user not found")
 			return
+		}
+
+		if auditErr := db.RecordAudit(r.Context(), "", "user.deleted", "user", userID, nil); auditErr != nil {
+			slog.Error("failed to record audit for user deletion", "error", auditErr)
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/store/migrations/004_retry.sql
+++ b/internal/store/migrations/004_retry.sql
@@ -1,0 +1,1 @@
+ALTER TABLE delivery_attempts ADD COLUMN retry_count INTEGER DEFAULT 0;


### PR DESCRIPTION
## Summary

- API key authentication with SHA-256 hashing, Bearer token middleware
- `turnis keys create/list/delete` CLI commands
- Structured audit log for all state-changing operations
- Prometheus metrics: alerts_total, notifications_dispatched_total, escalation_steps_fired_total, active_alerts gauge, notification_latency histogram
- `GET /readyz` health probe with DB ping
- `GET /metrics` Prometheus endpoint
- Versioned migrations: 002_auth.sql, 003_audit.sql, 004_retry.sql

## Code review

4 passes, 4 issues found and fixed:
- Goroutine used detached context instead of cancelled request context
- API key stored in request context via context.WithValue
- Status route moved outside auth middleware (no fragile path exemption)
- Metrics endpoint documented for network-level protection

## Test plan

- [x] `go build ./cmd/turnis` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Manual: `turnis keys create`, use key in Authorization header
- [ ] Manual: verify 401 without key on /api/v1/ routes
- [ ] Manual: verify /healthz, /readyz, /metrics accessible without key
- [ ] Manual: verify audit log entries via GET /api/v1/audit

Closes #26, closes #28, closes #30