### PR TITLE
Add delivery retry, e2e tests, and operator runbook

### DIFF
--- a/docs/deploy-docker-compose.md
+++ b/docs/deploy-docker-compose.md
@@ -1,0 +1,153 @@
+# Production Deployment with Docker Compose
+
+This guide provides a production-ready `docker-compose.yml` with PostgreSQL and Traefik for TLS termination.
+
+## Prerequisites
+
+- Docker and Docker Compose v2
+- A domain name with DNS pointing to your server
+- Ports 80 and 443 open for Traefik
+
+## docker-compose.yml
+
+```yaml
+services:
+  turnis:
+    image: ghcr.io/atoolz/turnis:latest
+    restart: unless-stopped
+    command: ["serve", "--config", "/etc/turnis/turnis.yaml"]
+    volumes:
+      - turnis-config:/etc/turnis
+    environment:
+      TURNIS_DATABASE_DRIVER: postgres
+      TURNIS_DATABASE_DSN: "postgres://turnis:${POSTGRES_PASSWORD}@postgres:5432/turnis?sslmode=disable"
+      TURNIS_SERVER_BASE_URL: "https://${TURNIS_DOMAIN}"
+      TURNIS_SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
+      TURNIS_SLACK_APP_TOKEN: "${SLACK_APP_TOKEN}"
+      TURNIS_SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.turnis.rule=Host(`${TURNIS_DOMAIN}`)"
+      - "traefik.http.routers.turnis.entrypoints=websecure"
+      - "traefik.http.routers.turnis.tls.certresolver=letsencrypt"
+      - "traefik.http.services.turnis.loadbalancer.server.port=8080"
+    networks:
+      - internal
+      - web
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: turnis
+      POSTGRES_USER: turnis
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U turnis -d turnis"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - internal
+
+  traefik:
+    image: traefik:v3.1
+    restart: unless-stopped
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=web"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - letsencrypt-data:/letsencrypt
+    networks:
+      - web
+
+volumes:
+  postgres-data:
+  turnis-config:
+  letsencrypt-data:
+
+networks:
+  internal:
+  web:
+    name: web
+```
+
+## .env file
+
+Create a `.env` file alongside your `docker-compose.yml`:
+
+```bash
+POSTGRES_PASSWORD=change-me-to-a-strong-password
+TURNIS_DOMAIN=turnis.example.com
+ACME_EMAIL=admin@example.com
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_APP_TOKEN=xapp-your-app-token
+SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+## Usage
+
+```bash
+# Start all services
+docker compose up -d
+
+# Check logs
+docker compose logs -f turnis
+
+# Stop
+docker compose down
+
+# Backup PostgreSQL
+docker compose exec postgres pg_dump -U turnis turnis > backup.sql
+
+# Upgrade Turnis
+docker compose pull turnis
+docker compose up -d turnis
+```
+
+## Health Check
+
+Turnis exposes `/healthz` on port 8080. The Docker health check polls this endpoint every 30 seconds. Traefik will only route traffic to healthy containers.
+
+## Volumes
+
+| Volume | Purpose |
+|---|---|
+| `postgres-data` | PostgreSQL data directory |
+| `turnis-config` | Turnis YAML config (mount your config here) |
+| `letsencrypt-data` | TLS certificates from Let's Encrypt |
+
+## Twilio and ntfy (optional)
+
+Add these environment variables to the `turnis` service if needed:
+
+```yaml
+environment:
+  TURNIS_TWILIO_ACCOUNT_SID: "${TWILIO_ACCOUNT_SID}"
+  TURNIS_TWILIO_AUTH_TOKEN: "${TWILIO_AUTH_TOKEN}"
+  TURNIS_TWILIO_FROM_NUMBER: "${TWILIO_FROM_NUMBER}"
+  TURNIS_NTFY_SERVER: "https://ntfy.sh"
+```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,166 @@
+# Operator Runbook
+
+## Backup and Restore
+
+### SQLite
+
+SQLite is a single file. Stop Turnis, copy the database, and start again.
+
+```bash
+# Backup
+cp turnis.db turnis.db.bak
+
+# Restore
+cp turnis.db.bak turnis.db
+```
+
+If Turnis is running with WAL mode (the default), also copy the WAL and SHM files if they exist:
+
+```bash
+cp turnis.db-wal turnis.db-wal.bak
+cp turnis.db-shm turnis.db-shm.bak
+```
+
+For a consistent backup without stopping Turnis, use the SQLite `.backup` command:
+
+```bash
+sqlite3 turnis.db ".backup turnis-backup.db"
+```
+
+### PostgreSQL
+
+```bash
+# Backup
+pg_dump -Fc turnis > turnis_$(date +%Y%m%d_%H%M%S).dump
+
+# Restore
+pg_restore -d turnis turnis_20240101_120000.dump
+```
+
+## Upgrading
+
+1. Stop the running Turnis process.
+2. Back up the database (see above).
+3. Replace the `turnis` binary with the new version.
+4. Start Turnis. Migrations run automatically on startup, no manual SQL needed.
+
+```bash
+systemctl stop turnis
+cp turnis.db turnis.db.pre-upgrade
+cp /path/to/new/turnis /usr/local/bin/turnis
+systemctl start turnis
+journalctl -u turnis -f  # watch for migration log lines
+```
+
+## Rotating API Keys
+
+Turnis API keys are managed via the CLI. The process is: create a new key, update any integrations or scripts that use the old key, then delete the old one.
+
+```bash
+# List existing keys
+turnis keys list
+
+# Create a new key
+turnis keys create --name "monitoring-v2"
+
+# Update your monitoring tool to use the new token, then delete the old one
+turnis keys delete <old-key-id>
+```
+
+## Rotating Slack and Twilio Tokens
+
+Slack bot tokens, app tokens, and Twilio credentials are set in the config file or environment variables. To rotate:
+
+1. Generate new credentials in the respective platform (Slack App settings, Twilio console).
+2. Update `turnis.yaml` or the corresponding environment variables:
+
+```yaml
+slack:
+  bot_token: "xoxb-new-token"
+  app_token: "xapp-new-token"
+  signing_secret: "new-secret"
+
+twilio:
+  account_sid: "ACnewsid"
+  auth_token: "new-auth-token"
+  from_number: "+15551234567"
+```
+
+Or via environment:
+
+```bash
+export TURNIS_SLACK_BOT_TOKEN=xoxb-new-token
+export TURNIS_SLACK_APP_TOKEN=xapp-new-token
+export TURNIS_TWILIO_AUTH_TOKEN=new-auth-token
+```
+
+3. Restart Turnis for the changes to take effect.
+
+```bash
+systemctl restart turnis
+```
+
+## Diagnosing Failed Escalations
+
+### Check delivery attempts in the database
+
+```sql
+-- Recent failed deliveries
+SELECT id, alert_id, user_id, channel, address, failure_reason, retry_count, dispatched_at, failed_at
+FROM delivery_attempts
+WHERE failed_at IS NOT NULL
+ORDER BY dispatched_at DESC
+LIMIT 20;
+
+-- Deliveries for a specific alert
+SELECT *
+FROM delivery_attempts
+WHERE alert_id = '<alert-id>'
+ORDER BY dispatched_at;
+```
+
+### Check logs
+
+Turnis logs escalation events with structured fields. Filter by alert_id to trace the full lifecycle.
+
+```bash
+# Systemd journal
+journalctl -u turnis | grep 'alert_id=<id>'
+
+# Docker
+docker logs turnis 2>&1 | grep 'alert_id=<id>'
+```
+
+Key log messages to look for:
+
+- `escalation: notifying user` confirms the engine attempted notification.
+- `notification dispatch failed` shows sender-level failures.
+- `retrying notification dispatch` shows retry attempts with backoff duration.
+- `notification dispatch permanently failed after retries` means all retries were exhausted.
+- `escalation: step timed out, escalating` means the step timeout elapsed without acknowledgment.
+- `escalation: exhausted all steps` means the policy ran through all steps and repeats.
+
+## Channel Down Recovery
+
+When a notification channel (Slack, Twilio, SMTP) is unreachable, Turnis applies the following retry behavior:
+
+**Transient errors (retried automatically):**
+- Network timeouts
+- Connection refused / connection reset
+- HTTP 5xx responses from the provider
+
+The dispatcher retries up to 3 times with exponential backoff: 1s, 4s, 16s (plus random 0-25% jitter). Each retry updates the `retry_count` column in `delivery_attempts`.
+
+**Non-transient errors (not retried):**
+- HTTP 4xx responses (bad request, unauthorized, forbidden)
+- Invalid addresses (malformed email, missing phone number)
+- Missing sender configuration
+
+After all retries are exhausted, the delivery is marked as permanently failed and the escalation engine continues to the next step in the policy. This means if Slack is fully down, the escalation will eventually reach an SMS or voice step if the policy is configured with multiple channels.
+
+**Recovery checklist:**
+
+1. Check the provider's status page (status.slack.com, status.twilio.com).
+2. Query `delivery_attempts` for `retry_count > 0` to see which deliveries hit retries.
+3. Once the channel recovers, new alerts will be delivered normally. Turnis does not re-deliver failed past notifications automatically.
+4. For critical alerts that were missed, manually re-fire them or acknowledge/resolve as appropriate.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,925 @@
+package api_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/atoolz/turnis/internal/alert"
+	"github.com/atoolz/turnis/internal/api"
+	"github.com/atoolz/turnis/internal/config"
+	"github.com/atoolz/turnis/internal/escalation"
+	"github.com/atoolz/turnis/internal/schedule"
+	"github.com/atoolz/turnis/internal/store"
+)
+
+const testAPIKey = "test-api-key-for-turnis-testing-1234"
+
+func setupTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.New(config.DatabaseConfig{
+		Driver: "sqlite",
+		DSN:    fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate())
+	// Allow a second connection so the background goroutine in APIKeyAuth
+	// (UpdateAPIKeyLastUsed) does not block the main request goroutine.
+	db.Conn().SetMaxOpenConns(2)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func setupTestServer(t *testing.T) (*httptest.Server, *store.DB) {
+	t.Helper()
+	db := setupTestDB(t)
+
+	// Create an API key for authenticating requests.
+	h := sha256.Sum256([]byte(testAPIKey))
+	hash := hex.EncodeToString(h[:])
+	_, err := db.CreateAPIKey(t.Context(), hash, "test-key", "")
+	require.NoError(t, err)
+
+	cfg := &config.Config{}
+	router := api.NewRouter(db, cfg, nil, nil)
+	srv := httptest.NewServer(router)
+	t.Cleanup(func() { srv.Close() })
+	return srv, db
+}
+
+func authRequest(method, url string, body io.Reader) *http.Request {
+	req, _ := http.NewRequest(method, url, body)
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func doJSON(t *testing.T, req *http.Request, target any) *http.Response {
+	t.Helper()
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if target != nil {
+		err = json.Unmarshal(body, target)
+		require.NoError(t, err)
+	}
+	return resp
+}
+
+func jsonBody(v any) *bytes.Buffer {
+	b, _ := json.Marshal(v)
+	return bytes.NewBuffer(b)
+}
+
+// --- Status ---
+
+func TestStatus(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/v1/status", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ok", body["status"])
+	assert.Equal(t, "turnis", body["service"])
+}
+
+// --- Auth ---
+
+func TestAuth_MissingHeader(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/v1/teams", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestAuth_InvalidKey(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/v1/teams", nil)
+	req.Header.Set("Authorization", "Bearer invalid-key")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// --- Teams API ---
+
+func TestTeams_CreateAndGet(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	body := jsonBody(map[string]string{"name": "platform", "slack_channel": "#platform"})
+	req := authRequest("POST", srv.URL+"/api/v1/teams", body)
+
+	var team store.Team
+	resp := doJSON(t, req, &team)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, team.ID)
+	assert.Equal(t, "platform", team.Name)
+	assert.Equal(t, "#platform", team.SlackChannel)
+
+	// GET specific team
+	req = authRequest("GET", srv.URL+"/api/v1/teams/"+team.ID, nil)
+	var got store.Team
+	resp = doJSON(t, req, &got)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, team.ID, got.ID)
+	assert.Equal(t, "platform", got.Name)
+}
+
+func TestTeams_CreateMissingName(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	body := jsonBody(map[string]string{"slack_channel": "#test"})
+	req := authRequest("POST", srv.URL+"/api/v1/teams", body)
+
+	var errResp map[string]string
+	resp := doJSON(t, req, &errResp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, errResp["error"], "name is required")
+}
+
+func TestTeams_List(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	// Create two teams
+	for _, name := range []string{"alpha", "beta"} {
+		req := authRequest("POST", srv.URL+"/api/v1/teams", jsonBody(map[string]string{"name": name}))
+		resp := doJSON(t, req, nil)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	}
+
+	req := authRequest("GET", srv.URL+"/api/v1/teams", nil)
+	var teams []store.Team
+	resp := doJSON(t, req, &teams)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, teams, 2)
+}
+
+func TestTeams_GetNonexistent(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := authRequest("GET", srv.URL+"/api/v1/teams/nonexistent-id", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestTeams_Delete(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	// Create
+	req := authRequest("POST", srv.URL+"/api/v1/teams", jsonBody(map[string]string{"name": "to-delete"}))
+	var team store.Team
+	doJSON(t, req, &team)
+
+	// Delete
+	req = authRequest("DELETE", srv.URL+"/api/v1/teams/"+team.ID, nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify gone
+	req = authRequest("GET", srv.URL+"/api/v1/teams/"+team.ID, nil)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// --- Users API ---
+
+func createTeam(t *testing.T, srv *httptest.Server) store.Team {
+	t.Helper()
+	req := authRequest("POST", srv.URL+"/api/v1/teams", jsonBody(map[string]string{"name": "test-team"}))
+	var team store.Team
+	resp := doJSON(t, req, &team)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	return team
+}
+
+func TestUsers_CreateWithAllFields(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	body := jsonBody(map[string]string{
+		"name":       "Alice",
+		"email":      "alice@example.com",
+		"phone":      "+1234567890",
+		"slack_id":   "U001",
+		"ntfy_topic": "alice-oncall",
+		"team_id":    team.ID,
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/users", body)
+
+	var user store.User
+	resp := doJSON(t, req, &user)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, user.ID)
+	assert.Equal(t, "Alice", user.Name)
+	assert.Equal(t, "alice@example.com", user.Email)
+	assert.Equal(t, "+1234567890", user.Phone)
+	assert.Equal(t, "U001", user.SlackID)
+	assert.Equal(t, "alice-oncall", user.NtfyTopic)
+	assert.Equal(t, team.ID, user.TeamID)
+}
+
+func TestUsers_CreateMissingFields(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	tests := []struct {
+		name string
+		body map[string]string
+		want string
+	}{
+		{"missing name", map[string]string{"email": "test@test.com"}, "name is required"},
+		{"missing email", map[string]string{"name": "Bob"}, "email is required"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(tc.body))
+			var errResp map[string]string
+			resp := doJSON(t, req, &errResp)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Contains(t, errResp["error"], tc.want)
+		})
+	}
+}
+
+func TestUsers_ListAll(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	for _, name := range []string{"Alice", "Bob"} {
+		req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+			"name":  name,
+			"email": name + "@test.com",
+		}))
+		resp := doJSON(t, req, nil)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	}
+
+	req := authRequest("GET", srv.URL+"/api/v1/users", nil)
+	var users []store.User
+	resp := doJSON(t, req, &users)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, users, 2)
+}
+
+func TestUsers_ListByTeam(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	// User with team
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Alice", "email": "alice@test.com", "team_id": team.ID,
+	}))
+	doJSON(t, req, nil)
+
+	// User without team
+	req = authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Bob", "email": "bob@test.com",
+	}))
+	doJSON(t, req, nil)
+
+	// Filter by team
+	req = authRequest("GET", srv.URL+"/api/v1/users?team_id="+team.ID, nil)
+	var users []store.User
+	resp := doJSON(t, req, &users)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, users, 1)
+	assert.Equal(t, "Alice", users[0].Name)
+}
+
+func TestUsers_GetSpecific(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Alice", "email": "alice@test.com",
+	}))
+	var user store.User
+	doJSON(t, req, &user)
+
+	req = authRequest("GET", srv.URL+"/api/v1/users/"+user.ID, nil)
+	var got store.User
+	resp := doJSON(t, req, &got)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, user.ID, got.ID)
+	assert.Equal(t, "Alice", got.Name)
+}
+
+func TestUsers_Update(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Alice", "email": "alice@test.com",
+	}))
+	var user store.User
+	doJSON(t, req, &user)
+
+	req = authRequest("PUT", srv.URL+"/api/v1/users/"+user.ID, jsonBody(map[string]string{
+		"name": "Alice Updated", "email": "alice2@test.com", "phone": "+999",
+	}))
+	var updated store.User
+	resp := doJSON(t, req, &updated)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "Alice Updated", updated.Name)
+	assert.Equal(t, "alice2@test.com", updated.Email)
+	assert.Equal(t, "+999", updated.Phone)
+}
+
+func TestUsers_Delete(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Alice", "email": "alice@test.com",
+	}))
+	var user store.User
+	doJSON(t, req, &user)
+
+	req = authRequest("DELETE", srv.URL+"/api/v1/users/"+user.ID, nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify gone
+	req = authRequest("GET", srv.URL+"/api/v1/users/"+user.ID, nil)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// --- Schedules API ---
+
+func createTeamAndUser(t *testing.T, srv *httptest.Server) (store.Team, store.User) {
+	t.Helper()
+	team := createTeam(t, srv)
+
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Alice", "email": "alice@test.com", "team_id": team.ID,
+	}))
+	var user store.User
+	resp := doJSON(t, req, &user)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	return team, user
+}
+
+func TestSchedules_Create(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team, user := createTeamAndUser(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "primary",
+		"team_id": team.ID,
+		"layers": []map[string]any{
+			{
+				"priority": 1,
+				"participants": []map[string]any{
+					{"user_id": user.ID, "position": 0},
+				},
+			},
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/schedules", body)
+
+	var sched schedule.Schedule
+	resp := doJSON(t, req, &sched)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, sched.ID)
+	assert.Equal(t, "primary", sched.Name)
+	assert.Equal(t, team.ID, sched.TeamID)
+}
+
+func TestSchedules_List(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team, user := createTeamAndUser(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "primary",
+		"team_id": team.ID,
+		"layers": []map[string]any{
+			{"priority": 1, "participants": []map[string]any{
+				{"user_id": user.ID, "position": 0},
+			}},
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/schedules", body)
+	doJSON(t, req, nil)
+
+	req = authRequest("GET", srv.URL+"/api/v1/schedules", nil)
+	var schedules []schedule.Schedule
+	resp := doJSON(t, req, &schedules)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, schedules, 1)
+}
+
+func TestSchedules_GetWithLayers(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team, user := createTeamAndUser(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "primary",
+		"team_id": team.ID,
+		"layers": []map[string]any{
+			{"priority": 1, "participants": []map[string]any{
+				{"user_id": user.ID, "position": 0},
+			}},
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/schedules", body)
+	var created schedule.Schedule
+	doJSON(t, req, &created)
+
+	req = authRequest("GET", srv.URL+"/api/v1/schedules/"+created.ID, nil)
+	var got schedule.Schedule
+	resp := doJSON(t, req, &got)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, created.ID, got.ID)
+	require.Len(t, got.Layers, 1)
+	assert.Equal(t, 1, got.Layers[0].Priority)
+	require.Len(t, got.Layers[0].Participants, 1)
+	assert.Equal(t, user.ID, got.Layers[0].Participants[0].UserID)
+}
+
+func TestSchedules_OnCall(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team, user := createTeamAndUser(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "primary",
+		"team_id": team.ID,
+		"layers": []map[string]any{
+			{"priority": 1, "participants": []map[string]any{
+				{"user_id": user.ID, "position": 0},
+			}},
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/schedules", body)
+	var created schedule.Schedule
+	doJSON(t, req, &created)
+
+	req = authRequest("GET", srv.URL+"/api/v1/schedules/on-call?schedule_id="+created.ID, nil)
+	var results []map[string]string
+	resp := doJSON(t, req, &results)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, results, 1)
+	assert.Equal(t, created.ID, results[0]["schedule_id"])
+	assert.Equal(t, user.ID, results[0]["user_id"])
+}
+
+func TestSchedules_CreateOverride(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team, user := createTeamAndUser(t, srv)
+
+	// Create another user for the override
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Bob", "email": "bob@test.com", "team_id": team.ID,
+	}))
+	var bob store.User
+	doJSON(t, req, &bob)
+
+	// Create schedule
+	body := jsonBody(map[string]any{
+		"name":    "primary",
+		"team_id": team.ID,
+		"layers": []map[string]any{
+			{"priority": 1, "participants": []map[string]any{
+				{"user_id": user.ID, "position": 0},
+			}},
+		},
+	})
+	req = authRequest("POST", srv.URL+"/api/v1/schedules", body)
+	var sched schedule.Schedule
+	doJSON(t, req, &sched)
+
+	// Create override
+	start := time.Now().Add(1 * time.Hour)
+	end := time.Now().Add(24 * time.Hour)
+	overrideBody := jsonBody(map[string]any{
+		"user_id":    bob.ID,
+		"start_time": start.Format(time.RFC3339),
+		"end_time":   end.Format(time.RFC3339),
+		"reason":     "vacation swap",
+	})
+	req = authRequest("POST", srv.URL+"/api/v1/schedules/"+sched.ID+"/overrides", overrideBody)
+	var override schedule.Override
+	resp := doJSON(t, req, &override)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, override.ID)
+	assert.Equal(t, bob.ID, override.UserID)
+	assert.Equal(t, sched.ID, override.ScheduleID)
+	assert.Equal(t, "vacation swap", override.Reason)
+}
+
+// --- Alerts API ---
+
+func createIntegration(t *testing.T, srv *httptest.Server, teamID string) store.Integration {
+	t.Helper()
+	req := authRequest("POST", srv.URL+"/api/v1/integrations", jsonBody(map[string]string{
+		"name":    "test-webhook",
+		"team_id": teamID,
+		"type":    "webhook",
+	}))
+	var integration store.Integration
+	resp := doJSON(t, req, &integration)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	return integration
+}
+
+func TestAlerts_Ingest(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	body := jsonBody(map[string]any{
+		"integration_id": integration.ID,
+		"alert": map[string]any{
+			"title":       "CPU > 90%",
+			"message":     "CPU usage is critical",
+			"severity":    "critical",
+			"source":      "prometheus",
+			"fingerprint": "cpu-001",
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/alerts", body)
+
+	var a alert.Alert
+	resp := doJSON(t, req, &a)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, a.ID)
+	assert.Equal(t, "CPU > 90%", a.Title)
+	assert.Equal(t, alert.StatusFiring, a.Status)
+	assert.Equal(t, alert.SeverityCritical, a.Severity)
+}
+
+func TestAlerts_IngestMissingTitle(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	body := jsonBody(map[string]any{
+		"integration_id": integration.ID,
+		"alert":          map[string]any{"message": "no title"},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/alerts", body)
+
+	var errResp map[string]string
+	resp := doJSON(t, req, &errResp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, errResp["error"], "title is required")
+}
+
+func TestAlerts_List(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	// Ingest two alerts
+	for _, title := range []string{"alert-1", "alert-2"} {
+		body := jsonBody(map[string]any{
+			"integration_id": integration.ID,
+			"alert":          map[string]any{"title": title},
+		})
+		req := authRequest("POST", srv.URL+"/api/v1/alerts", body)
+		doJSON(t, req, nil)
+	}
+
+	req := authRequest("GET", srv.URL+"/api/v1/alerts", nil)
+	var alerts []alert.Alert
+	resp := doJSON(t, req, &alerts)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, alerts, 2)
+}
+
+func TestAlerts_ListByStatus(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	body := jsonBody(map[string]any{
+		"integration_id": integration.ID,
+		"alert":          map[string]any{"title": "test-alert"},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/alerts", body)
+	doJSON(t, req, nil)
+
+	// Filter by firing
+	req = authRequest("GET", srv.URL+"/api/v1/alerts?status=firing", nil)
+	var firing []alert.Alert
+	resp := doJSON(t, req, &firing)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, firing, 1)
+
+	// Filter by resolved (none)
+	req = authRequest("GET", srv.URL+"/api/v1/alerts?status=resolved", nil)
+	var resolved []alert.Alert
+	resp = doJSON(t, req, &resolved)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, resolved, 0)
+}
+
+func TestAlerts_Acknowledge(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	// Create user
+	req := authRequest("POST", srv.URL+"/api/v1/users", jsonBody(map[string]string{
+		"name": "Alice", "email": "alice@test.com", "team_id": team.ID,
+	}))
+	var user store.User
+	doJSON(t, req, &user)
+
+	// Ingest alert
+	body := jsonBody(map[string]any{
+		"integration_id": integration.ID,
+		"alert":          map[string]any{"title": "test-alert"},
+	})
+	req = authRequest("POST", srv.URL+"/api/v1/alerts", body)
+	var a alert.Alert
+	doJSON(t, req, &a)
+
+	// Acknowledge
+	req = authRequest("POST", srv.URL+"/api/v1/alerts/"+a.ID+"/ack", jsonBody(map[string]string{
+		"user_id": user.ID,
+	}))
+	var acked alert.Alert
+	resp := doJSON(t, req, &acked)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, alert.StatusAcknowledged, acked.Status)
+	assert.Equal(t, user.ID, acked.AcknowledgedBy)
+	assert.NotNil(t, acked.AcknowledgedAt)
+}
+
+func TestAlerts_Resolve(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	body := jsonBody(map[string]any{
+		"integration_id": integration.ID,
+		"alert":          map[string]any{"title": "test-alert"},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/alerts", body)
+	var a alert.Alert
+	doJSON(t, req, &a)
+
+	// Resolve
+	req = authRequest("POST", srv.URL+"/api/v1/alerts/"+a.ID+"/resolve", bytes.NewBuffer([]byte("{}")))
+	var resolved alert.Alert
+	resp := doJSON(t, req, &resolved)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, alert.StatusResolved, resolved.Status)
+	assert.NotNil(t, resolved.ResolvedAt)
+}
+
+// --- Webhook API ---
+
+func TestWebhook_IngestViaToken(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	body := jsonBody(map[string]any{
+		"title":    "webhook alert",
+		"severity": "warning",
+	})
+	req, _ := http.NewRequest("POST", srv.URL+"/webhook/"+integration.Token, body)
+	req.Header.Set("Content-Type", "application/json")
+
+	var a alert.Alert
+	resp := doJSON(t, req, &a)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, "webhook alert", a.Title)
+	assert.Equal(t, alert.StatusFiring, a.Status)
+}
+
+func TestWebhook_InvalidToken(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	body := jsonBody(map[string]any{"title": "webhook alert"})
+	req, _ := http.NewRequest("POST", srv.URL+"/webhook/invalid-token-value", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestWebhook_Deduplication(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	payload := map[string]any{
+		"title":       "dup alert",
+		"fingerprint": "dedup-001",
+	}
+
+	// First ingestion: should create
+	req, _ := http.NewRequest("POST", srv.URL+"/webhook/"+integration.Token, jsonBody(payload))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// Second ingestion: should deduplicate
+	req, _ = http.NewRequest("POST", srv.URL+"/webhook/"+integration.Token, jsonBody(payload))
+	req.Header.Set("Content-Type", "application/json")
+	var dedupResp map[string]any
+	resp = doJSON(t, req, &dedupResp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, true, dedupResp["deduplicated"])
+}
+
+// --- Escalation Policies API ---
+
+func TestPolicies_Create(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "critical-esc",
+		"team_id": team.ID,
+		"repeat":  2,
+		"steps": []map[string]any{
+			{"step_order": 0, "timeout_seconds": 300, "notify_channel": "slack"},
+			{"step_order": 1, "timeout_seconds": 600, "notify_channel": "sms"},
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/escalation-policies", body)
+
+	var policy escalation.Policy
+	resp := doJSON(t, req, &policy)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, policy.ID)
+	assert.Equal(t, "critical-esc", policy.Name)
+	assert.Equal(t, 2, policy.Repeat)
+}
+
+func TestPolicies_List(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "test-policy",
+		"team_id": team.ID,
+		"steps":   []map[string]any{{"step_order": 0, "timeout_seconds": 300, "notify_channel": "slack"}},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/escalation-policies", body)
+	doJSON(t, req, nil)
+
+	req = authRequest("GET", srv.URL+"/api/v1/escalation-policies", nil)
+	var policies []escalation.Policy
+	resp := doJSON(t, req, &policies)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, policies, 1)
+}
+
+func TestPolicies_GetWithSteps(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "test-policy",
+		"team_id": team.ID,
+		"repeat":  3,
+		"steps": []map[string]any{
+			{"step_order": 0, "timeout_seconds": 300, "notify_channel": "slack"},
+			{"step_order": 1, "timeout_seconds": 600, "notify_channel": "sms"},
+		},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/escalation-policies", body)
+	var created escalation.Policy
+	doJSON(t, req, &created)
+
+	req = authRequest("GET", srv.URL+"/api/v1/escalation-policies/"+created.ID, nil)
+	var got escalation.Policy
+	resp := doJSON(t, req, &got)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "test-policy", got.Name)
+	assert.Equal(t, 3, got.Repeat)
+	require.Len(t, got.Steps, 2)
+	assert.Equal(t, 0, got.Steps[0].StepOrder)
+	assert.Equal(t, 300, got.Steps[0].TimeoutSeconds)
+	assert.Equal(t, "slack", got.Steps[0].NotifyChannel)
+	assert.Equal(t, 1, got.Steps[1].StepOrder)
+	assert.Equal(t, "sms", got.Steps[1].NotifyChannel)
+}
+
+func TestPolicies_Delete(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	body := jsonBody(map[string]any{
+		"name":    "to-delete",
+		"team_id": team.ID,
+		"steps":   []map[string]any{{"step_order": 0, "timeout_seconds": 300, "notify_channel": "slack"}},
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/escalation-policies", body)
+	var policy escalation.Policy
+	doJSON(t, req, &policy)
+
+	req = authRequest("DELETE", srv.URL+"/api/v1/escalation-policies/"+policy.ID, nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify gone
+	req = authRequest("GET", srv.URL+"/api/v1/escalation-policies/"+policy.ID, nil)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// --- Integrations API ---
+
+func TestIntegrations_Create(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	body := jsonBody(map[string]string{
+		"name":    "grafana-webhook",
+		"team_id": team.ID,
+		"type":    "webhook",
+	})
+	req := authRequest("POST", srv.URL+"/api/v1/integrations", body)
+
+	var integration store.Integration
+	resp := doJSON(t, req, &integration)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEmpty(t, integration.ID)
+	assert.NotEmpty(t, integration.Token)
+	assert.Len(t, integration.Token, 64) // 32 bytes hex-encoded
+	assert.Equal(t, "grafana-webhook", integration.Name)
+	assert.Equal(t, "webhook", integration.Type)
+}
+
+func TestIntegrations_List(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+
+	for _, name := range []string{"int-1", "int-2"} {
+		req := authRequest("POST", srv.URL+"/api/v1/integrations", jsonBody(map[string]string{
+			"name": name, "team_id": team.ID,
+		}))
+		doJSON(t, req, nil)
+	}
+
+	req := authRequest("GET", srv.URL+"/api/v1/integrations", nil)
+	var integrations []store.Integration
+	resp := doJSON(t, req, &integrations)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, integrations, 2)
+}
+
+func TestIntegrations_Delete(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	team := createTeam(t, srv)
+	integration := createIntegration(t, srv, team.ID)
+
+	req := authRequest("DELETE", srv.URL+"/api/v1/integrations/"+integration.ID, nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Verify list is empty
+	req = authRequest("GET", srv.URL+"/api/v1/integrations", nil)
+	var integrations []store.Integration
+	resp = doJSON(t, req, &integrations)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, integrations, 0)
+}

--- a/internal/escalation/engine_test.go
+++ b/internal/escalation/engine_test.go
@@ -1,0 +1,654 @@
+package escalation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Fake Store ---
+
+type fakeStore struct {
+	mu sync.Mutex
+
+	alerts            map[string]Alert
+	integrations      map[string]Integration
+	policies          map[string]*Policy
+	schedules         map[string]Schedule
+	overrides         map[string][]Override
+	users             map[string]User
+	notificationRules map[string][]NotificationRule
+
+	deliveries       []deliveryRecord
+	escalatedAlerts  []string
+}
+
+type deliveryRecord struct {
+	alertID, userID, channel, address string
+	success                          bool
+	failureReason                    string
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		alerts:            make(map[string]Alert),
+		integrations:      make(map[string]Integration),
+		policies:          make(map[string]*Policy),
+		schedules:         make(map[string]Schedule),
+		overrides:         make(map[string][]Override),
+		users:             make(map[string]User),
+		notificationRules: make(map[string][]NotificationRule),
+	}
+}
+
+func (s *fakeStore) GetAlert(_ context.Context, id string) (Alert, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.alerts[id]
+	if !ok {
+		return Alert{}, fmt.Errorf("alert %q not found", id)
+	}
+	return a, nil
+}
+
+func (s *fakeStore) GetIntegration(_ context.Context, id string) (Integration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i, ok := s.integrations[id]
+	if !ok {
+		return Integration{}, fmt.Errorf("integration %q not found", id)
+	}
+	return i, nil
+}
+
+func (s *fakeStore) GetPolicy(_ context.Context, id string) (*Policy, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.policies[id]
+	if !ok {
+		return nil, fmt.Errorf("policy %q not found", id)
+	}
+	return p, nil
+}
+
+func (s *fakeStore) GetSchedule(_ context.Context, id string) (Schedule, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sc, ok := s.schedules[id]
+	if !ok {
+		return Schedule{}, fmt.Errorf("schedule %q not found", id)
+	}
+	return sc, nil
+}
+
+func (s *fakeStore) GetOverrides(_ context.Context, scheduleID string) ([]Override, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.overrides[scheduleID], nil
+}
+
+func (s *fakeStore) GetUser(_ context.Context, id string) (User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[id]
+	if !ok {
+		return User{}, fmt.Errorf("user %q not found", id)
+	}
+	return u, nil
+}
+
+func (s *fakeStore) GetNotificationRules(_ context.Context, userID string) ([]NotificationRule, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notificationRules[userID], nil
+}
+
+func (s *fakeStore) RecordDelivery(_ context.Context, alertID, userID, channel, address string, success bool, failureReason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliveries = append(s.deliveries, deliveryRecord{
+		alertID:       alertID,
+		userID:        userID,
+		channel:       channel,
+		address:       address,
+		success:       success,
+		failureReason: failureReason,
+	})
+	return nil
+}
+
+func (s *fakeStore) MarkDeliveryEscalated(_ context.Context, alertID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.escalatedAlerts = append(s.escalatedAlerts, alertID)
+	return nil
+}
+
+// --- Fake Notifier ---
+
+type notifyCall struct {
+	channel    string
+	address    string
+	alert      Alert
+	user       User
+	ackURL     string
+	resolveURL string
+}
+
+type fakeNotifier struct {
+	mu    sync.Mutex
+	calls []notifyCall
+	// called is closed after the first Notify call to signal tests.
+	called chan struct{}
+	once   sync.Once
+	// callCount tracks total calls atomically.
+	callCount atomic.Int32
+}
+
+func newFakeNotifier() *fakeNotifier {
+	return &fakeNotifier{
+		called: make(chan struct{}),
+	}
+}
+
+func (n *fakeNotifier) Notify(_ context.Context, channel, address string, a Alert, u User, ackURL, resolveURL string) (bool, error) {
+	n.mu.Lock()
+	n.calls = append(n.calls, notifyCall{
+		channel:    channel,
+		address:    address,
+		alert:      a,
+		user:       u,
+		ackURL:     ackURL,
+		resolveURL: resolveURL,
+	})
+	n.mu.Unlock()
+	n.callCount.Add(1)
+	n.once.Do(func() { close(n.called) })
+	return true, nil
+}
+
+func (n *fakeNotifier) getCalls() []notifyCall {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	cp := make([]notifyCall, len(n.calls))
+	copy(cp, n.calls)
+	return cp
+}
+
+// --- Test helpers ---
+
+// seedDefaults populates the store with a minimal alert -> integration -> policy -> user chain.
+// The policy has steps with short timeouts for fast tests.
+func seedDefaults(store *fakeStore, policySteps []Step, policyRepeat int) {
+	store.alerts["alert-1"] = Alert{
+		ID:            "alert-1",
+		IntegrationID: "int-1",
+		Title:         "CPU high",
+		Message:       "CPU > 90%",
+		Severity:      "critical",
+		Status:        "firing",
+	}
+	store.integrations["int-1"] = Integration{
+		ID:                 "int-1",
+		EscalationPolicyID: "pol-1",
+	}
+	store.policies["pol-1"] = &Policy{
+		ID:     "pol-1",
+		Name:   "default",
+		TeamID: "team-1",
+		Repeat: policyRepeat,
+		Steps:  policySteps,
+	}
+	store.users["user-1"] = User{
+		ID:    "user-1",
+		Name:  "Alice",
+		Email: "alice@example.com",
+		Phone: "+1234567890",
+	}
+}
+
+func defaultSteps() []Step {
+	return []Step{
+		{
+			ID:             "step-1",
+			PolicyID:       "pol-1",
+			StepOrder:      0,
+			TimeoutSeconds: 1, // 1s for fast tests
+			NotifyUserID:   "user-1",
+			NotifyChannel:  "email",
+		},
+	}
+}
+
+func twoSteps() []Step {
+	return []Step{
+		{
+			ID:             "step-1",
+			PolicyID:       "pol-1",
+			StepOrder:      0,
+			TimeoutSeconds: 1,
+			NotifyUserID:   "user-1",
+			NotifyChannel:  "email",
+		},
+		{
+			ID:             "step-2",
+			PolicyID:       "pol-1",
+			StepOrder:      1,
+			TimeoutSeconds: 1,
+			NotifyUserID:   "user-1",
+			NotifyChannel:  "sms",
+		},
+	}
+}
+
+// waitForNotifications waits until the notifier has at least n calls or the timeout fires.
+func waitForNotifications(t *testing.T, notifier *fakeNotifier, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		if int(notifier.callCount.Load()) >= n {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d notifications, got %d", n, notifier.callCount.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// --- Tests ---
+
+func TestEngine_EnqueueStartsEscalation(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	seedDefaults(store, defaultSteps(), 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+
+	select {
+	case <-notifier.called:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("notifier was not called within 2s")
+	}
+
+	calls := notifier.getCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "email", calls[0].channel)
+	assert.Equal(t, "alice@example.com", calls[0].address)
+	assert.Equal(t, "alert-1", calls[0].alert.ID)
+	assert.Equal(t, "http://localhost/api/v1/alerts/alert-1/ack", calls[0].ackURL)
+	assert.Equal(t, "http://localhost/api/v1/alerts/alert-1/resolve", calls[0].resolveURL)
+}
+
+func TestEngine_AcknowledgeCancelsTimer(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	steps := twoSteps()
+	// Increase timeout so escalation won't fire before ack.
+	steps[0].TimeoutSeconds = 10
+	seedDefaults(store, steps, 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+
+	// Wait for first notification.
+	select {
+	case <-notifier.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first notification not received")
+	}
+
+	eng.Acknowledge("alert-1")
+	assert.Equal(t, 0, eng.ActiveCount())
+
+	// Wait to confirm no second notification fires.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 1, int(notifier.callCount.Load()), "should have exactly 1 notification after ack")
+}
+
+func TestEngine_ResolveCancelsTimer(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	steps := twoSteps()
+	steps[0].TimeoutSeconds = 10
+	seedDefaults(store, steps, 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+
+	select {
+	case <-notifier.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first notification not received")
+	}
+
+	eng.Resolve("alert-1")
+	assert.Equal(t, 0, eng.ActiveCount())
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 1, int(notifier.callCount.Load()), "should have exactly 1 notification after resolve")
+}
+
+func TestEngine_EscalatesOnTimeout(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	steps := twoSteps()
+	// Very short timeout so escalation fires quickly.
+	steps[0].TimeoutSeconds = 1
+	steps[1].TimeoutSeconds = 10
+	seedDefaults(store, steps, 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+
+	// Wait for both step-1 and step-2 notifications.
+	waitForNotifications(t, notifier, 2, 5*time.Second)
+
+	calls := notifier.getCalls()
+	require.GreaterOrEqual(t, len(calls), 2)
+	assert.Equal(t, "email", calls[0].channel)
+	assert.Equal(t, "sms", calls[1].channel)
+}
+
+func TestEngine_ExhaustedStepsStopsEscalation(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	// Single step, repeat=1 (no repeat).
+	steps := []Step{
+		{
+			ID:             "step-1",
+			PolicyID:       "pol-1",
+			StepOrder:      0,
+			TimeoutSeconds: 1,
+			NotifyUserID:   "user-1",
+			NotifyChannel:  "email",
+		},
+	}
+	seedDefaults(store, steps, 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+
+	// Wait for notification + timeout + cleanup.
+	waitForNotifications(t, notifier, 1, 2*time.Second)
+	// Wait for the timer to fire and exhaust.
+	time.Sleep(2 * time.Second)
+
+	assert.Equal(t, 1, int(notifier.callCount.Load()), "should have exactly 1 notification when steps exhaust")
+	assert.Equal(t, 0, eng.ActiveCount(), "engine should have no active alerts after exhaustion")
+}
+
+func TestEngine_RepeatPolicy(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	steps := []Step{
+		{
+			ID:             "step-1",
+			PolicyID:       "pol-1",
+			StepOrder:      0,
+			TimeoutSeconds: 1,
+			NotifyUserID:   "user-1",
+			NotifyChannel:  "email",
+		},
+	}
+	// repeat=2 means step fires twice (repeat 0 and repeat 1).
+	seedDefaults(store, steps, 2)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+
+	// Should get 2 notifications: step-1 repeat 0 and step-1 repeat 1.
+	waitForNotifications(t, notifier, 2, 5*time.Second)
+
+	calls := notifier.getCalls()
+	require.GreaterOrEqual(t, len(calls), 2)
+	assert.Equal(t, "email", calls[0].channel)
+	assert.Equal(t, "email", calls[1].channel)
+}
+
+func TestEngine_DuplicateEnqueueIgnored(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	steps := defaultSteps()
+	steps[0].TimeoutSeconds = 10
+	seedDefaults(store, steps, 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	eng.Enqueue("alert-1")
+	eng.Enqueue("alert-1") // duplicate
+
+	select {
+	case <-notifier.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first notification not received")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 1, int(notifier.callCount.Load()), "duplicate enqueue should not cause extra notification")
+}
+
+func TestEngine_ShutdownDrainsTimers(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	steps := defaultSteps()
+	steps[0].TimeoutSeconds = 60 // long timeout so timer is still pending
+	seedDefaults(store, steps, 1)
+
+	eng := NewEngine(store, notifier, "http://localhost")
+
+	eng.Enqueue("alert-1")
+
+	select {
+	case <-notifier.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first notification not received")
+	}
+
+	eng.Shutdown()
+	assert.Equal(t, 0, eng.ActiveCount(), "ActiveCount should be 0 after shutdown")
+}
+
+func TestEngine_ConcurrentEnqueueAcknowledge(t *testing.T) {
+	store := newFakeStore()
+	notifier := newFakeNotifier()
+	seedDefaults(store, defaultSteps(), 1)
+
+	// Add more alerts.
+	for i := 2; i <= 10; i++ {
+		id := fmt.Sprintf("alert-%d", i)
+		store.alerts[id] = Alert{
+			ID:            id,
+			IntegrationID: "int-1",
+			Title:         "test",
+			Severity:      "warning",
+			Status:        "firing",
+		}
+	}
+
+	eng := NewEngine(store, notifier, "http://localhost")
+	defer eng.Shutdown()
+
+	var wg sync.WaitGroup
+	for i := 1; i <= 10; i++ {
+		id := fmt.Sprintf("alert-%d", i)
+		wg.Add(2)
+		go func(alertID string) {
+			defer wg.Done()
+			eng.Enqueue(alertID)
+		}(id)
+		go func(alertID string) {
+			defer wg.Done()
+			time.Sleep(50 * time.Millisecond)
+			eng.Acknowledge(alertID)
+		}(id)
+	}
+	wg.Wait()
+
+	// Should not panic or deadlock. ActiveCount should eventually reach 0.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 0, eng.ActiveCount())
+}
+
+func TestEngine_ResolveChannel(t *testing.T) {
+	// resolveChannel is unexported but testable from within the package.
+	utc := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC) // 14:30 UTC
+
+	tests := []struct {
+		name     string
+		rules    []NotificationRule
+		fallback string
+		now      time.Time
+		want     string
+	}{
+		{
+			name:     "no rules returns fallback",
+			rules:    nil,
+			fallback: "email",
+			now:      utc,
+			want:     "email",
+		},
+		{
+			name: "rule without time window always matches",
+			rules: []NotificationRule{
+				{Channel: "slack", Priority: 10},
+			},
+			fallback: "email",
+			now:      utc,
+			want:     "slack",
+		},
+		{
+			name: "highest priority rule wins",
+			rules: []NotificationRule{
+				{Channel: "email", Priority: 1},
+				{Channel: "sms", Priority: 5},
+				{Channel: "slack", Priority: 10},
+			},
+			fallback: "email",
+			now:      utc,
+			want:     "slack",
+		},
+		{
+			name: "normal time window match",
+			rules: []NotificationRule{
+				{Channel: "slack", Priority: 10, StartTime: "09:00", EndTime: "17:00", Timezone: "UTC"},
+			},
+			fallback: "email",
+			now:      utc, // 14:30 is within 09:00-17:00
+			want:     "slack",
+		},
+		{
+			name: "normal time window no match",
+			rules: []NotificationRule{
+				{Channel: "slack", Priority: 10, StartTime: "09:00", EndTime: "12:00", Timezone: "UTC"},
+			},
+			fallback: "email",
+			now:      utc, // 14:30 is outside 09:00-12:00
+			want:     "email",
+		},
+		{
+			name: "overnight window match before midnight",
+			rules: []NotificationRule{
+				{Channel: "sms", Priority: 10, StartTime: "22:00", EndTime: "08:00", Timezone: "UTC"},
+			},
+			fallback: "email",
+			now:      time.Date(2025, 6, 15, 23, 0, 0, 0, time.UTC), // 23:00
+			want:     "sms",
+		},
+		{
+			name: "overnight window match after midnight",
+			rules: []NotificationRule{
+				{Channel: "sms", Priority: 10, StartTime: "22:00", EndTime: "08:00", Timezone: "UTC"},
+			},
+			fallback: "email",
+			now:      time.Date(2025, 6, 15, 3, 0, 0, 0, time.UTC), // 03:00
+			want:     "sms",
+		},
+		{
+			name: "overnight window no match",
+			rules: []NotificationRule{
+				{Channel: "sms", Priority: 10, StartTime: "22:00", EndTime: "08:00", Timezone: "UTC"},
+			},
+			fallback: "email",
+			now:      utc, // 14:30
+			want:     "email",
+		},
+		{
+			name: "higher priority time-bound rule takes precedence over lower always-on",
+			rules: []NotificationRule{
+				{Channel: "email", Priority: 1},
+				{Channel: "slack", Priority: 10, StartTime: "09:00", EndTime: "17:00", Timezone: "UTC"},
+			},
+			fallback: "webhook",
+			now:      utc,
+			want:     "slack",
+		},
+		{
+			name: "falls through time-bound miss to lower always-on rule",
+			rules: []NotificationRule{
+				{Channel: "email", Priority: 1},
+				{Channel: "slack", Priority: 10, StartTime: "09:00", EndTime: "12:00", Timezone: "UTC"},
+			},
+			fallback: "webhook",
+			now:      utc, // 14:30 misses slack window
+			want:     "email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveChannel(tt.rules, tt.fallback, tt.now)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEngine_ParseHHMM(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"00:00", 0},
+		{"09:30", 9*60 + 30},
+		{"23:59", 23*60 + 59},
+		{"12:00", 12 * 60},
+		// Invalid inputs
+		{"", -1},
+		{"9:30", -1},
+		{"25:00", -1},
+		{"12:60", -1},
+		{"ab:cd", -1},
+		{"12-00", -1},
+		{"123:00", -1},
+		{"12:0", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseHHMM(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/notify/dispatcher_test.go
+++ b/internal/notify/dispatcher_test.go
@@ -1,0 +1,187 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Fake Sender ---
+
+type fakeSender struct {
+	channel Channel
+	calls   []Message
+	err     error
+}
+
+func (s *fakeSender) Send(_ context.Context, msg Message) (*DeliveryResult, error) {
+	s.calls = append(s.calls, msg)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &DeliveryResult{
+		MessageID:  "msg-123",
+		ChannelRef: "ref-456",
+		Channel:    s.channel,
+		Success:    true,
+		SentAt:     time.Now(),
+	}, nil
+}
+
+func (s *fakeSender) Name() Channel {
+	return s.channel
+}
+
+// --- Tests ---
+
+func TestDispatcher_RegisterAndDispatch(t *testing.T) {
+	d := NewDispatcher()
+	sender := &fakeSender{channel: ChannelSlack}
+	d.Register(sender)
+
+	msg := Message{
+		AlertID: "alert-1",
+		UserID:  "user-1",
+		Channel: ChannelSlack,
+		Address: "U12345",
+		Title:   "CPU high",
+		Body:    "CPU > 90%",
+	}
+
+	result, err := d.Dispatch(context.Background(), msg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Success)
+	assert.Equal(t, ChannelSlack, result.Channel)
+	assert.Equal(t, "msg-123", result.MessageID)
+	assert.Equal(t, "ref-456", result.ChannelRef)
+
+	require.Len(t, sender.calls, 1)
+	assert.Equal(t, "alert-1", sender.calls[0].AlertID)
+	assert.Equal(t, "U12345", sender.calls[0].Address)
+}
+
+func TestDispatcher_UnknownChannel(t *testing.T) {
+	d := NewDispatcher()
+
+	msg := Message{
+		AlertID: "alert-1",
+		Channel: ChannelSMS,
+	}
+
+	result, err := d.Dispatch(context.Background(), msg)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no sender registered")
+	assert.Contains(t, err.Error(), "sms")
+}
+
+func TestDispatcher_AvailableChannels(t *testing.T) {
+	d := NewDispatcher()
+	d.Register(&fakeSender{channel: ChannelSlack})
+	d.Register(&fakeSender{channel: ChannelEmail})
+	d.Register(&fakeSender{channel: ChannelSMS})
+
+	channels := d.AvailableChannels()
+	sort.Slice(channels, func(i, j int) bool { return channels[i] < channels[j] })
+
+	require.Len(t, channels, 3)
+	assert.Equal(t, ChannelEmail, channels[0])
+	assert.Equal(t, ChannelSlack, channels[1])
+	assert.Equal(t, ChannelSMS, channels[2])
+}
+
+func TestDispatcher_DispatchFailure(t *testing.T) {
+	d := NewDispatcher()
+	senderErr := errors.New("connection refused")
+	sender := &fakeSender{channel: ChannelEmail, err: senderErr}
+	d.Register(sender)
+
+	msg := Message{
+		AlertID: "alert-1",
+		Channel: ChannelEmail,
+		Address: "alice@example.com",
+	}
+
+	result, err := d.Dispatch(context.Background(), msg)
+
+	require.Error(t, err)
+	assert.Equal(t, senderErr, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Equal(t, "connection refused", result.Error)
+	assert.Equal(t, ChannelEmail, result.Channel)
+}
+
+func TestDispatcher_DispatchWithRetry_UnknownChannel(t *testing.T) {
+	d := NewDispatcher()
+
+	msg := Message{
+		AlertID: "alert-1",
+		Channel: ChannelVoice,
+	}
+
+	result, err := d.DispatchWithRetry(context.Background(), msg, "", nil)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "no sender registered")
+}
+
+func TestDispatcher_DispatchWithRetry_NonTransientFailsImmediately(t *testing.T) {
+	d := NewDispatcher()
+	sender := &fakeSender{
+		channel: ChannelSlack,
+		err:     errors.New("invalid token"),
+	}
+	d.Register(sender)
+
+	msg := Message{
+		AlertID: "alert-1",
+		Channel: ChannelSlack,
+	}
+
+	result, err := d.DispatchWithRetry(context.Background(), msg, "", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid token")
+	require.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Equal(t, 0, result.RetryCount, "non-transient error should not retry")
+	require.Len(t, sender.calls, 1)
+}
+
+func TestDispatcher_RegisterOverwrites(t *testing.T) {
+	d := NewDispatcher()
+
+	sender1 := &fakeSender{channel: ChannelSlack, err: errors.New("old sender")}
+	sender2 := &fakeSender{channel: ChannelSlack}
+	d.Register(sender1)
+	d.Register(sender2)
+
+	msg := Message{
+		AlertID: "alert-1",
+		Channel: ChannelSlack,
+	}
+
+	result, err := d.Dispatch(context.Background(), msg)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	// sender2 should have been called, not sender1.
+	assert.Len(t, sender1.calls, 0)
+	assert.Len(t, sender2.calls, 1)
+}
+
+func TestDispatcher_EmptyChannels(t *testing.T) {
+	d := NewDispatcher()
+	channels := d.AvailableChannels()
+	assert.Empty(t, channels)
+}

--- a/internal/web/templates/alerts.html
+++ b/internal/web/templates/alerts.html
@@ -4,18 +4,18 @@
 <div class="filter-bar">
     <label>Status
         <select name="status" hx-get="/web/partials/alert-list" hx-target="#alert-table" hx-swap="innerHTML" hx-include="[name='severity']">
-            <option value="" {{if eq .FilterStatus ""}}>selected{{end}}>All</option>
-            <option value="firing" {{if eq .FilterStatus "firing"}}selected{{end}}>Firing</option>
-            <option value="acknowledged" {{if eq .FilterStatus "acknowledged"}}selected{{end}}>Acknowledged</option>
-            <option value="resolved" {{if eq .FilterStatus "resolved"}}selected{{end}}>Resolved</option>
+            <option value="" selected>All</option>
+            <option value="firing">Firing</option>
+            <option value="acknowledged">Acknowledged</option>
+            <option value="resolved">Resolved</option>
         </select>
     </label>
     <label>Severity
         <select name="severity" hx-get="/web/partials/alert-list" hx-target="#alert-table" hx-swap="innerHTML" hx-include="[name='status']">
-            <option value="" {{if eq .FilterSeverity ""}}>selected{{end}}>All</option>
-            <option value="critical" {{if eq .FilterSeverity "critical"}}selected{{end}}>Critical</option>
-            <option value="warning" {{if eq .FilterSeverity "warning"}}selected{{end}}>Warning</option>
-            <option value="info" {{if eq .FilterSeverity "info"}}selected{{end}}>Info</option>
+            <option value="" selected>All</option>
+            <option value="critical">Critical</option>
+            <option value="warning">Warning</option>
+            <option value="info">Info</option>
         </select>
     </label>
 </div>

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -1,0 +1,466 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/atoolz/turnis/internal/alert"
+	"github.com/atoolz/turnis/internal/config"
+	"github.com/atoolz/turnis/internal/schedule"
+	"github.com/atoolz/turnis/internal/store"
+)
+
+func setupWebTest(t *testing.T) (*httptest.Server, *store.DB) {
+	t.Helper()
+	db, err := store.New(config.DatabaseConfig{
+		Driver: "sqlite",
+		DSN:    fmt.Sprintf("file:%s?mode=memory&cache=private", t.Name()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate())
+	t.Cleanup(func() { db.Close() })
+
+	handler := NewHandler(db)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return srv, db
+}
+
+func get(t *testing.T, srv *httptest.Server, path string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(srv.URL + path)
+	require.NoError(t, err)
+	return resp
+}
+
+func bodyString(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// --- Home ---
+
+func TestHome_EmptyDB(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	resp := get(t, srv, "/")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "No schedules configured")
+	assert.Contains(t, body, "Dashboard")
+}
+
+func TestHome_WithData(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "web-team", "#oncall")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Alice Web", "alice@web.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	_, err = db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "web-primary",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "web-primary")
+	assert.Contains(t, body, "Alice Web")
+}
+
+// --- Schedules ---
+
+func TestSchedules_List(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "sched-team", "")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Bob Sched", "bob@sched.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	_, err = db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "sched-alpha",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/schedules")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "sched-alpha")
+	assert.Contains(t, body, "Bob Sched")
+	assert.Contains(t, body, "Schedules")
+}
+
+func TestSchedules_Detail(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "detail-team", "")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Carol Detail", "carol@detail.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	sched, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "detail-sched",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/schedules/"+sched.ID)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "detail-sched")
+	assert.Contains(t, body, "Carol Detail")
+	assert.Contains(t, body, "Layers")
+	assert.Contains(t, body, "Overrides")
+}
+
+func TestSchedules_DetailNotFound(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	resp := get(t, srv, "/schedules/nonexistent-id")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// --- Alerts ---
+
+func TestAlerts_EmptyList(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	resp := get(t, srv, "/alerts")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "Alerts")
+	assert.Contains(t, body, "No alerts match the current filters")
+}
+
+func TestAlerts_WithData(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "alert-team", "")
+	require.NoError(t, err)
+
+	integration, err := db.CreateIntegration(ctx, "alert-hook", team.ID, "webhook", "")
+	require.NoError(t, err)
+
+	_, err = db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+		Title:    "CPU on fire",
+		Severity: alert.SeverityCritical,
+		Source:   "prometheus",
+	})
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/alerts")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "CPU on fire")
+	assert.Contains(t, body, "critical")
+	assert.Contains(t, body, "prometheus")
+}
+
+func TestAlerts_FilterByStatus(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "filter-team", "")
+	require.NoError(t, err)
+
+	integration, err := db.CreateIntegration(ctx, "filter-hook", team.ID, "webhook", "")
+	require.NoError(t, err)
+
+	firingAlert, err := db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+		Title:    "Still firing alert",
+		Severity: alert.SeverityWarning,
+	})
+	require.NoError(t, err)
+
+	resolvedAlert, err := db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+		Title:    "Already resolved alert",
+		Severity: alert.SeverityInfo,
+	})
+	require.NoError(t, err)
+	_, err = db.ResolveAlert(ctx, resolvedAlert.ID)
+	require.NoError(t, err)
+
+	// Filter by firing status
+	resp := get(t, srv, "/alerts?status=firing")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, firingAlert.Title)
+	assert.NotContains(t, body, resolvedAlert.Title)
+
+	// Filter by resolved status
+	resp2 := get(t, srv, "/alerts?status=resolved")
+	body2 := bodyString(t, resp2)
+	assert.Contains(t, body2, resolvedAlert.Title)
+	assert.NotContains(t, body2, firingAlert.Title)
+}
+
+// --- Teams ---
+
+func TestTeams_List(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	_, err := db.CreateTeam(ctx, "infra-team", "#infra-oncall")
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/teams")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "infra-team")
+	assert.Contains(t, body, "#infra-oncall")
+	assert.Contains(t, body, "Teams")
+}
+
+func TestTeams_Create(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	form := url.Values{}
+	form.Set("name", "new-team")
+	form.Set("slack_channel", "#new-oncall")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.PostForm(srv.URL+"/teams", form)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, "/teams", resp.Header.Get("Location"))
+}
+
+func TestTeams_Detail(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "detail-team", "#detail-chan")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Dan Detail", "dan@detail.test", "+15551234567", "", "", team.ID)
+	require.NoError(t, err)
+
+	_, err = db.CreateIntegration(ctx, "detail-webhook", team.ID, "webhook", "")
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/teams/"+team.ID)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "detail-team")
+	assert.Contains(t, body, user.Name)
+	assert.Contains(t, body, "detail-webhook")
+	assert.Contains(t, body, "Integrations")
+	assert.Contains(t, body, "Members")
+}
+
+func TestTeams_DetailNotFound(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	resp := get(t, srv, "/teams/nonexistent-id")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// --- Users ---
+
+func TestUsers_List(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "user-team", "")
+	require.NoError(t, err)
+
+	_, err = db.CreateUser(ctx, "Eve Users", "eve@users.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/users")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, "Eve Users")
+	assert.Contains(t, body, "eve@users.test")
+	assert.Contains(t, body, "Users")
+}
+
+func TestUsers_Create(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	form := url.Values{}
+	form.Set("name", "Frank New")
+	form.Set("email", "frank@new.test")
+	form.Set("phone", "+15559876543")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.PostForm(srv.URL+"/users", form)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, "/users", resp.Header.Get("Location"))
+}
+
+// --- Partials ---
+
+func TestOnCallPartial(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "partial-team", "")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Grace Partial", "grace@partial.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	_, err = db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "partial-sched",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp := get(t, srv, "/web/oncall")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+
+	body := bodyString(t, resp)
+	// Partial should not include full layout (no <!DOCTYPE html>)
+	assert.NotContains(t, body, "<!DOCTYPE html>")
+	assert.Contains(t, body, "partial-sched")
+	assert.Contains(t, body, "Grace Partial")
+}
+
+// --- Static ---
+
+func TestStaticCSS(t *testing.T) {
+	srv, _ := setupWebTest(t)
+
+	resp := get(t, srv, "/static/app.css")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/css")
+
+	body := bodyString(t, resp)
+	assert.Contains(t, body, ".badge")
+}
+
+// --- Override creation via web form ---
+
+func TestSchedules_CreateOverride(t *testing.T) {
+	srv, db := setupWebTest(t)
+	ctx := context.Background()
+
+	team, err := db.CreateTeam(ctx, "override-team", "")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Hank Override", "hank@override.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	sched, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "override-sched",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("user_id", user.ID)
+	form.Set("end_time", time.Now().Add(24*time.Hour).Format("2006-01-02T15:04"))
+	form.Set("reason", "vacation cover")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.PostForm(srv.URL+"/schedules/"+sched.ID+"/overrides", form)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, "/schedules/"+sched.ID, resp.Header.Get("Location"))
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,658 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/atoolz/turnis/internal/alert"
+	"github.com/atoolz/turnis/internal/config"
+	"github.com/atoolz/turnis/internal/escalation"
+	"github.com/atoolz/turnis/internal/schedule"
+	"github.com/atoolz/turnis/internal/store"
+)
+
+// fakeNotifier records notifications for assertions.
+type fakeNotifier struct {
+	mu      sync.Mutex
+	calls   []notifyCall
+	succeed bool
+}
+
+type notifyCall struct {
+	Channel string
+	Address string
+	AlertID string
+	UserID  string
+}
+
+func (f *fakeNotifier) Notify(_ context.Context, channel, address string, a escalation.Alert, u escalation.User, _, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, notifyCall{
+		Channel: channel,
+		Address: address,
+		AlertID: a.ID,
+		UserID:  u.ID,
+	})
+	if !f.succeed {
+		return false, fmt.Errorf("fake notifier failure")
+	}
+	return true, nil
+}
+
+func (f *fakeNotifier) Calls() []notifyCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]notifyCall, len(f.calls))
+	copy(cp, f.calls)
+	return cp
+}
+
+// storeAdapter adapts *store.DB to escalation.Store.
+type storeAdapter struct {
+	db *store.DB
+}
+
+func (a *storeAdapter) GetAlert(ctx context.Context, id string) (escalation.Alert, error) {
+	al, err := a.db.GetAlert(ctx, id)
+	if err != nil {
+		return escalation.Alert{}, err
+	}
+	return escalation.Alert{
+		ID:            al.ID,
+		IntegrationID: al.IntegrationID,
+		Title:         al.Title,
+		Message:       al.Message,
+		Severity:      string(al.Severity),
+		Status:        string(al.Status),
+	}, nil
+}
+
+func (a *storeAdapter) GetIntegration(ctx context.Context, id string) (escalation.Integration, error) {
+	i, err := a.db.GetIntegration(ctx, id)
+	if err != nil {
+		return escalation.Integration{}, err
+	}
+	return escalation.Integration{
+		ID:                 i.ID,
+		EscalationPolicyID: i.EscalationPolicyID,
+	}, nil
+}
+
+func (a *storeAdapter) GetPolicy(ctx context.Context, id string) (*escalation.Policy, error) {
+	return a.db.GetPolicy(ctx, id)
+}
+
+func (a *storeAdapter) GetSchedule(ctx context.Context, id string) (escalation.Schedule, error) {
+	s, err := a.db.GetSchedule(ctx, id)
+	if err != nil {
+		return escalation.Schedule{}, err
+	}
+
+	sched := escalation.Schedule{
+		ID:             s.ID,
+		Timezone:       s.Timezone,
+		RotationType:   escalation.RotationType(s.RotationType),
+		RotationLength: s.RotationLength,
+		HandoffTime:    s.HandoffTime,
+		HandoffDay:     s.HandoffDay,
+		CreatedAt:      s.CreatedAt,
+	}
+
+	for _, l := range s.Layers {
+		layer := escalation.Layer{Priority: l.Priority}
+		for _, p := range l.Participants {
+			layer.Participants = append(layer.Participants, escalation.Participant{UserID: p.UserID})
+		}
+		sched.Layers = append(sched.Layers, layer)
+	}
+
+	return sched, nil
+}
+
+func (a *storeAdapter) GetOverrides(ctx context.Context, scheduleID string) ([]escalation.Override, error) {
+	ovs, err := a.db.GetOverrides(ctx, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]escalation.Override, len(ovs))
+	for i, o := range ovs {
+		result[i] = escalation.Override{
+			UserID:    o.UserID,
+			StartTime: o.StartTime,
+			EndTime:   o.EndTime,
+		}
+	}
+	return result, nil
+}
+
+func (a *storeAdapter) GetUser(ctx context.Context, id string) (escalation.User, error) {
+	u, err := a.db.GetUser(ctx, id)
+	if err != nil {
+		return escalation.User{}, err
+	}
+	return escalation.User{
+		ID:        u.ID,
+		Name:      u.Name,
+		Email:     u.Email,
+		Phone:     u.Phone,
+		SlackID:   u.SlackID,
+		NtfyTopic: u.NtfyTopic,
+	}, nil
+}
+
+func (a *storeAdapter) GetNotificationRules(ctx context.Context, userID string) ([]escalation.NotificationRule, error) {
+	rules, err := a.db.ListNotificationRules(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]escalation.NotificationRule, len(rules))
+	for i, r := range rules {
+		result[i] = escalation.NotificationRule{
+			Channel:   r.Channel,
+			Priority:  r.Priority,
+			StartTime: r.StartTime,
+			EndTime:   r.EndTime,
+			Timezone:  r.Timezone,
+		}
+	}
+	return result, nil
+}
+
+func (a *storeAdapter) RecordDelivery(ctx context.Context, alertID, userID, channel, address string, success bool, failureReason string) error {
+	_, err := a.db.RecordDelivery(ctx, alertID, userID, channel, address, success, failureReason)
+	return err
+}
+
+func (a *storeAdapter) MarkDeliveryEscalated(ctx context.Context, alertID string) error {
+	return a.db.MarkDeliveryEscalated(ctx, alertID)
+}
+
+func setupTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.New(config.DatabaseConfig{
+		Driver: "sqlite",
+		DSN:    fmt.Sprintf("file:%s?mode=memory&cache=private", t.Name()),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate())
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestFullLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	// 1. Create team
+	team, err := db.CreateTeam(ctx, "e2e-team", "#e2e-oncall")
+	require.NoError(t, err)
+
+	// 2. Create user
+	user, err := db.CreateUser(ctx, "Alice", "alice@e2e.test", "+15551234567", "U_ALICE", "", team.ID)
+	require.NoError(t, err)
+
+	// 3. Create schedule with one participant
+	sched, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "e2e-primary",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 4. Create escalation policy pointing at the schedule
+	policy, err := db.CreatePolicy(ctx, &escalation.Policy{
+		Name:   "e2e-policy",
+		TeamID: team.ID,
+		Repeat: 1,
+		Steps: []escalation.Step{
+			{
+				StepOrder:        0,
+				TimeoutSeconds:   1, // 1 second so the test does not wait long
+				NotifyScheduleID: sched.ID,
+				NotifyChannel:    "slack",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// 5. Create integration linked to the policy
+	integration, err := db.CreateIntegration(ctx, "e2e-webhook", team.ID, "webhook", policy.ID)
+	require.NoError(t, err)
+
+	// 6. Fire an alert
+	a, err := db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+		Title:    "E2E test alert",
+		Message:  "Something is broken",
+		Severity: alert.SeverityCritical,
+		Source:   "e2e-test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, alert.StatusFiring, a.Status)
+
+	// 7. Set up fake notifier and engine
+	notifier := &fakeNotifier{succeed: true}
+	sa := &storeAdapter{db: db}
+	engine := escalation.NewEngine(sa, notifier, "http://localhost:8080")
+	defer engine.Shutdown()
+
+	// 8. Enqueue the alert for escalation
+	engine.Enqueue(a.ID)
+
+	// 9. Wait for escalation step to fire (give it some time for async processing)
+	require.Eventually(t, func() bool {
+		return len(notifier.Calls()) >= 1
+	}, 5*time.Second, 50*time.Millisecond, "expected at least one notification call")
+
+	// 10. Verify notification was sent to the right user
+	calls := notifier.Calls()
+	assert.Equal(t, "slack", calls[0].Channel)
+	assert.Equal(t, a.ID, calls[0].AlertID)
+	assert.Equal(t, user.ID, calls[0].UserID)
+
+	// 11. Verify delivery attempt was recorded
+	deliveries, err := db.ListRecentDeliveries(ctx, 10)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(deliveries), 1)
+
+	found := false
+	for _, d := range deliveries {
+		if d.AlertID == a.ID && d.UserID == user.ID {
+			found = true
+			assert.Equal(t, "slack", d.Channel)
+			break
+		}
+	}
+	assert.True(t, found, "delivery attempt for the alert should be recorded")
+
+	// 12. Acknowledge alert
+	acked, err := db.AcknowledgeAlert(ctx, a.ID, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, alert.StatusAcknowledged, acked.Status)
+
+	// 13. Tell the engine the alert was acknowledged
+	engine.Acknowledge(a.ID)
+
+	// 14. Verify engine stopped tracking the alert
+	assert.Equal(t, 0, engine.ActiveCount(), "engine should have no active escalations after ack")
+}
+
+func TestFullLifecycle_ResolveStopsEscalation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	team, err := db.CreateTeam(ctx, "resolve-team", "")
+	require.NoError(t, err)
+	user, err := db.CreateUser(ctx, "Bob", "bob@e2e.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	sched, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "resolve-sched",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	policy, err := db.CreatePolicy(ctx, &escalation.Policy{
+		Name:   "resolve-policy",
+		TeamID: team.ID,
+		Repeat: 1,
+		Steps: []escalation.Step{
+			{
+				StepOrder:        0,
+				TimeoutSeconds:   60, // Long timeout so it does not escalate before we resolve
+				NotifyScheduleID: sched.ID,
+				NotifyChannel:    "slack",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	integration, err := db.CreateIntegration(ctx, "resolve-hook", team.ID, "webhook", policy.ID)
+	require.NoError(t, err)
+
+	a, err := db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+		Title:    "resolve test",
+		Severity: alert.SeverityWarning,
+	})
+	require.NoError(t, err)
+
+	notifier := &fakeNotifier{succeed: true}
+	sa := &storeAdapter{db: db}
+	engine := escalation.NewEngine(sa, notifier, "http://localhost:8080")
+	defer engine.Shutdown()
+
+	engine.Enqueue(a.ID)
+
+	// Wait for notification
+	require.Eventually(t, func() bool {
+		return len(notifier.Calls()) >= 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Resolve the alert
+	resolved, err := db.ResolveAlert(ctx, a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, alert.StatusResolved, resolved.Status)
+
+	engine.Resolve(a.ID)
+	assert.Equal(t, 0, engine.ActiveCount())
+}
+
+func TestE2E_WebhookIngestAndDedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	team, err := db.CreateTeam(ctx, "dedup-team", "")
+	require.NoError(t, err)
+
+	integration, err := db.CreateIntegration(ctx, "dedup-hook", team.ID, "webhook", "")
+	require.NoError(t, err)
+
+	incoming := alert.IncomingAlert{
+		Title:       "Disk full",
+		Severity:    alert.SeverityCritical,
+		Source:      "node-exporter",
+		Fingerprint: "disk-full-abc123",
+	}
+
+	// First alert should be created
+	a1, err := db.CreateAlert(ctx, integration.ID, incoming)
+	require.NoError(t, err)
+	assert.Equal(t, alert.StatusFiring, a1.Status)
+
+	// Simulate dedup check: look for existing alerts with same fingerprint
+	existing, err := db.GetAlertsByFingerprint(ctx, integration.ID, incoming.Fingerprint)
+	require.NoError(t, err)
+
+	dup := alert.Deduplicate(existing, incoming)
+	require.NotNil(t, dup, "second firing with same fingerprint should match existing alert")
+	assert.Equal(t, a1.ID, dup.ID)
+
+	// After resolving, dedup should NOT match
+	_, err = db.ResolveAlert(ctx, a1.ID)
+	require.NoError(t, err)
+
+	existing2, err := db.GetAlertsByFingerprint(ctx, integration.ID, incoming.Fingerprint)
+	require.NoError(t, err)
+
+	dup2 := alert.Deduplicate(existing2, incoming)
+	assert.Nil(t, dup2, "resolved alert should not match dedup")
+}
+
+func TestE2E_OverrideChangesOnCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	team, err := db.CreateTeam(ctx, "override-team", "")
+	require.NoError(t, err)
+
+	alice, err := db.CreateUser(ctx, "Alice Primary", "alice@override.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	bob, err := db.CreateUser(ctx, "Bob Override", "bob@override.test", "", "", "", team.ID)
+	require.NoError(t, err)
+
+	sched, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "override-sched",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: alice.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Without override, Alice is on-call
+	overrides, err := db.GetOverrides(ctx, sched.ID)
+	require.NoError(t, err)
+
+	onCall := schedule.WhosOnCall(sched, overrides, time.Now())
+	assert.Equal(t, alice.ID, onCall, "Alice should be on-call without override")
+
+	// Create override for Bob covering now
+	now := time.Now().UTC()
+	_, err = db.CreateOverride(ctx, sched.ID, bob.ID, now.Add(-1*time.Hour), now.Add(24*time.Hour), "Alice is sick")
+	require.NoError(t, err)
+
+	// With override, Bob is on-call
+	overrides2, err := db.GetOverrides(ctx, sched.ID)
+	require.NoError(t, err)
+
+	onCall2 := schedule.WhosOnCall(sched, overrides2, time.Now())
+	assert.Equal(t, bob.ID, onCall2, "Bob should be on-call with active override")
+}
+
+func TestE2E_MultiStepEscalation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	team, err := db.CreateTeam(ctx, "multi-team", "")
+	require.NoError(t, err)
+
+	alice, err := db.CreateUser(ctx, "Alice Step1", "alice@multi.test", "", "U_ALICE_M", "", team.ID)
+	require.NoError(t, err)
+
+	bob, err := db.CreateUser(ctx, "Bob Step2", "bob@multi.test", "+15559990000", "", "", team.ID)
+	require.NoError(t, err)
+
+	sched1, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "multi-sched-1",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: alice.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	sched2, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "multi-sched-2",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: bob.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	policy, err := db.CreatePolicy(ctx, &escalation.Policy{
+		Name:   "multi-step-policy",
+		TeamID: team.ID,
+		Repeat: 1,
+		Steps: []escalation.Step{
+			{
+				StepOrder:        0,
+				TimeoutSeconds:   1,
+				NotifyScheduleID: sched1.ID,
+				NotifyChannel:    "slack",
+			},
+			{
+				StepOrder:        1,
+				TimeoutSeconds:   1,
+				NotifyScheduleID: sched2.ID,
+				NotifyChannel:    "sms",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	integration, err := db.CreateIntegration(ctx, "multi-hook", team.ID, "webhook", policy.ID)
+	require.NoError(t, err)
+
+	a, err := db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+		Title:    "Multi-step test",
+		Severity: alert.SeverityCritical,
+	})
+	require.NoError(t, err)
+
+	notifier := &fakeNotifier{succeed: true}
+	sa := &storeAdapter{db: db}
+	engine := escalation.NewEngine(sa, notifier, "http://localhost:8080")
+	defer engine.Shutdown()
+
+	engine.Enqueue(a.ID)
+
+	// Wait for both steps to fire (step 0 fires immediately, step 1 after 1s timeout)
+	require.Eventually(t, func() bool {
+		return len(notifier.Calls()) >= 2
+	}, 10*time.Second, 100*time.Millisecond, "expected at least 2 notification calls for 2 escalation steps")
+
+	calls := notifier.Calls()
+
+	// Step 0 should notify Alice via slack
+	assert.Equal(t, "slack", calls[0].Channel)
+	assert.Equal(t, alice.ID, calls[0].UserID)
+	assert.Equal(t, a.ID, calls[0].AlertID)
+
+	// Step 1 should notify Bob via sms
+	assert.Equal(t, "sms", calls[1].Channel)
+	assert.Equal(t, bob.ID, calls[1].UserID)
+	assert.Equal(t, a.ID, calls[1].AlertID)
+}
+
+func TestE2E_ConcurrentAlerts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	team, err := db.CreateTeam(ctx, "concurrent-team", "")
+	require.NoError(t, err)
+
+	user, err := db.CreateUser(ctx, "Concurrent User", "concurrent@test.test", "", "U_CONC", "", team.ID)
+	require.NoError(t, err)
+
+	sched, err := db.CreateSchedule(ctx, &schedule.Schedule{
+		Name:   "concurrent-sched",
+		TeamID: team.ID,
+		Layers: []schedule.Layer{
+			{
+				Priority: 1,
+				Participants: []schedule.Participant{
+					{UserID: user.ID, Position: 0},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	policy, err := db.CreatePolicy(ctx, &escalation.Policy{
+		Name:   "concurrent-policy",
+		TeamID: team.ID,
+		Repeat: 1,
+		Steps: []escalation.Step{
+			{
+				StepOrder:        0,
+				TimeoutSeconds:   60,
+				NotifyScheduleID: sched.ID,
+				NotifyChannel:    "slack",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	integration, err := db.CreateIntegration(ctx, "concurrent-hook", team.ID, "webhook", policy.ID)
+	require.NoError(t, err)
+
+	notifier := &fakeNotifier{succeed: true}
+	sa := &storeAdapter{db: db}
+	engine := escalation.NewEngine(sa, notifier, "http://localhost:8080")
+	defer engine.Shutdown()
+
+	const alertCount = 10
+	alertIDs := make([]string, alertCount)
+
+	// Create all alerts first
+	for i := 0; i < alertCount; i++ {
+		a, err := db.CreateAlert(ctx, integration.ID, alert.IncomingAlert{
+			Title:    fmt.Sprintf("Concurrent alert %d", i),
+			Severity: alert.SeverityWarning,
+			Source:   "load-test",
+		})
+		require.NoError(t, err)
+		alertIDs[i] = a.ID
+	}
+
+	// Enqueue all concurrently
+	var wg sync.WaitGroup
+	for _, id := range alertIDs {
+		wg.Add(1)
+		go func(alertID string) {
+			defer wg.Done()
+			engine.Enqueue(alertID)
+		}(id)
+	}
+	wg.Wait()
+
+	// Wait for all notifications
+	require.Eventually(t, func() bool {
+		return len(notifier.Calls()) >= alertCount
+	}, 15*time.Second, 100*time.Millisecond,
+		"expected at least %d notifications, got %d", alertCount, len(notifier.Calls()))
+
+	calls := notifier.Calls()
+	assert.GreaterOrEqual(t, len(calls), alertCount)
+
+	// Verify every alert ID was notified
+	notified := make(map[string]bool)
+	for _, c := range calls {
+		notified[c.AlertID] = true
+	}
+	for _, id := range alertIDs {
+		assert.True(t, notified[id], "alert %s should have been notified", id)
+	}
+}


### PR DESCRIPTION
## Summary

- Delivery retry with exponential backoff (1s, 4s, 16s) + jitter for transient failures
- E2E tests: full alert lifecycle against real SQLite (create team -> schedule -> policy -> integration -> fire alert -> ack -> resolve)
- API handler tests, web UI tests, escalation engine tests, dispatcher retry tests
- Operator runbook: backup/restore, upgrades, key rotation, diagnostics
- Production docker-compose with Postgres and Traefik TLS

## Test plan

- [x] `go build ./cmd/turnis` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all packages)

Closes #29, closes #31, closes #32